### PR TITLE
Split inplace/not inplace transform

### DIFF
--- a/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -13,10 +13,10 @@ import kotlin.reflect.full.primaryConstructor
  */
 private val <T : Node> T.containmentProperties: Collection<KProperty1<T, *>>
     get() = this.javaClass.kotlin.memberProperties
-            .filter { it.visibility == KVisibility.PUBLIC }
-            .filter { it.findAnnotation<Derived>() == null }
-            .filter { it.findAnnotation<Link>() == null }
-            .filter { it.name != "parent" }
+        .filter { it.visibility == KVisibility.PUBLIC }
+        .filter { it.findAnnotation<Derived>() == null }
+        .filter { it.findAnnotation<Link>() == null }
+        .filter { it.name != "parent" }
 
 /**
  * Sets or corrects the parent of all AST nodes.
@@ -94,18 +94,18 @@ data class PropertyDescription(val name: String, val provideNodes: Boolean, val 
                 provideNodes(classifier)
             }
             return PropertyDescription(
-                    name = property.name,
-                    provideNodes = provideNodes,
-                    multiple = multiple,
-                    value = property.get(node)
+                name = property.name,
+                provideNodes = provideNodes,
+                multiple = multiple,
+                value = property.get(node)
             )
         }
     }
 }
 
 fun Node.processProperties(
-        propertiesToIgnore: Set<String> = setOf("parseTreeNode", "position", "specifiedPosition"),
-        propertyOperation: (PropertyDescription) -> Unit
+    propertiesToIgnore: Set<String> = setOf("parseTreeNode", "position", "specifiedPosition"),
+    propertyOperation: (PropertyDescription) -> Unit
 ) {
     containmentProperties.forEach { p ->
         if (!propertiesToIgnore.contains(p.name)) {
@@ -228,7 +228,7 @@ fun Node.transform(operation: (Node) -> Node, inPlace: Boolean = false): Node {
 }
 
 class ImmutablePropertyException(property: KProperty<*>, node: Node) :
-        RuntimeException("Cannot mutate property '${property.name}' of node $node (class: ${node.javaClass.canonicalName})")
+    RuntimeException("Cannot mutate property '${property.name}' of node $node (class: ${node.javaClass.canonicalName})")
 
 fun Node.transformChildrenInPlace(operation: (Node) -> Node) {
     relevantMemberProperties().forEach { property ->


### PR DESCRIPTION
In my opinion you always know if you want to transform in place or not when writing your code. So when I remove the boolean and make two separate methods for transformChildren, it becomes more readable and usable in my opinion. One getting/setting on the existing nodes, the other is creating new objects.