### PR TITLE
Create a depth-first AST traversing sequence

### DIFF
--- a/src/main/kotlin/com/strumenta/kolasu/model/Navigation.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Navigation.kt
@@ -4,11 +4,5 @@ package com.strumenta.kolasu.model
  * @return the nearest ancestor of this node that is an instance of klass.
  */
 fun <T : Node> Node.ancestor(klass: Class<T>): T? {
-    if (this.parent != null) {
-        if (klass.isInstance(this.parent)) {
-            return this.parent as T
-        }
-        return this.parent!!.ancestor(klass)
-    }
-    return null
+    return walkAncestors().filterIsInstance(klass).firstOrNull()
 }

--- a/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -33,8 +33,8 @@ fun Node.assignParents() {
 /**
  * Recursively execute "operation" on this node, and all nodes below this node.
  */
-fun Node.processNodes(operation: (Node) -> Unit) {
-    walk().forEach(operation)
+fun Node.processNodes(operation: (Node) -> Unit, walker: KFunction1<Node, Sequence<Node>> = Node::walk) {
+    walker.invoke(this).forEach(operation)
 }
 
 private fun provideNodes(kTypeProjection: KTypeProjection): Boolean {
@@ -110,22 +110,22 @@ fun Node.processProperties(
 /**
  * @return the first node in the AST for which the predicate is true. Null if none are found.
  */
-fun Node.find(predicate: (Node) -> Boolean): Node? {
-    return walk().find(predicate)
+fun Node.find(predicate: (Node) -> Boolean, walker: KFunction1<Node, Sequence<Node>> = Node::walk): Node? {
+    return walker.invoke(this).find(predicate)
 }
 
 /**
  * Recursively execute "operation" on this node, and all nodes below this node that extend klass.
  */
-fun <T : Node> Node.specificProcess(klass: Class<T>, operation: (T) -> Unit) {
-    walk().filterIsInstance(klass).forEach(operation)
+fun <T : Node> Node.specificProcess(klass: Class<T>, operation: (T) -> Unit, walker: KFunction1<Node, Sequence<Node>> = Node::walk) {
+    walker.invoke(this).filterIsInstance(klass).forEach(operation)
 }
 
 /**
  * @return all nodes in this AST (sub)tree that extend klass.
  */
-fun <T : Node> Node.collectByType(klass: Class<T>): List<T> {
-    return walk().filterIsInstance(klass).toList()
+fun <T : Node> Node.collectByType(klass: Class<T>, walker: KFunction1<Node, Sequence<Node>> = Node::walk): List<T> {
+    return walker.invoke(this).filterIsInstance(klass).toList()
 }
 
 /**

--- a/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -30,6 +30,7 @@ fun Node.assignParents() {
 
 /**
  * Recursively execute "operation" on this node, and all nodes below this node.
+ * @param walker the function that generates the nodes to operate on in the desired sequence.
  */
 fun Node.processNodes(operation: (Node) -> Unit, walker: KFunction1<Node, Sequence<Node>> = Node::walk) {
     walker.invoke(this).forEach(operation)
@@ -106,6 +107,7 @@ fun Node.processProperties(
 }
 
 /**
+ * @param walker the function that generates the nodes to operate on in the desired sequence.
  * @return the first node in the AST for which the predicate is true. Null if none are found.
  */
 fun Node.find(predicate: (Node) -> Boolean, walker: KFunction1<Node, Sequence<Node>> = Node::walk): Node? {
@@ -114,13 +116,15 @@ fun Node.find(predicate: (Node) -> Boolean, walker: KFunction1<Node, Sequence<No
 
 /**
  * Recursively execute "operation" on this node, and all nodes below this node that extend klass.
+ * @param walker the function that generates the nodes to operate on in the desired sequence.
  */
 fun <T : Node> Node.specificProcess(klass: Class<T>, operation: (T) -> Unit, walker: KFunction1<Node, Sequence<Node>> = Node::walk) {
     walker.invoke(this).filterIsInstance(klass).forEach(operation)
 }
 
 /**
- * @return all nodes in this AST (sub)tree that extend klass.
+ * @param walker the function that generates the nodes to operate on in the desired sequence.
+ * @return all nodes in this AST (sub)tree that are instances of, or extend klass.
  */
 fun <T : Node> Node.collectByType(klass: Class<T>, walker: KFunction1<Node, Sequence<Node>> = Node::walk): List<T> {
     return walker.invoke(this).filterIsInstance(klass).toList()

--- a/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -11,10 +11,10 @@ import kotlin.reflect.full.primaryConstructor
  */
 internal val <T : Node> T.containmentProperties: Collection<KProperty1<T, *>>
     get() = this.javaClass.kotlin.memberProperties
-            .filter { it.visibility == KVisibility.PUBLIC }
-            .filter { it.findAnnotation<Derived>() == null }
-            .filter { it.findAnnotation<Link>() == null }
-            .filter { it.name != "parent" }
+        .filter { it.visibility == KVisibility.PUBLIC }
+        .filter { it.findAnnotation<Derived>() == null }
+        .filter { it.findAnnotation<Link>() == null }
+        .filter { it.name != "parent" }
 
 /**
  * Sets or corrects the parent of all AST nodes.
@@ -86,18 +86,18 @@ data class PropertyDescription(val name: String, val provideNodes: Boolean, val 
                 provideNodes(classifier)
             }
             return PropertyDescription(
-                    name = property.name,
-                    provideNodes = provideNodes,
-                    multiple = multiple,
-                    value = property.get(node)
+                name = property.name,
+                provideNodes = provideNodes,
+                multiple = multiple,
+                value = property.get(node)
             )
         }
     }
 }
 
 fun Node.processProperties(
-        propertiesToIgnore: Set<String> = setOf("parseTreeNode", "position", "specifiedPosition"),
-        propertyOperation: (PropertyDescription) -> Unit
+    propertiesToIgnore: Set<String> = setOf("parseTreeNode", "position", "specifiedPosition"),
+    propertyOperation: (PropertyDescription) -> Unit
 ) {
     containmentProperties.forEach { p ->
         if (!propertiesToIgnore.contains(p.name)) {
@@ -196,7 +196,7 @@ fun Node.transform(operation: (Node) -> Node, inPlace: Boolean = false): Node {
 }
 
 class ImmutablePropertyException(property: KProperty<*>, node: Node) :
-        RuntimeException("Cannot mutate property '${property.name}' of node $node (class: ${node.javaClass.canonicalName})")
+    RuntimeException("Cannot mutate property '${property.name}' of node $node (class: ${node.javaClass.canonicalName})")
 
 fun Node.transformChildren(operation: (Node) -> Node, inPlace: Boolean = false): Node {
     val changes = mutableMapOf<String, Any>()

--- a/src/main/kotlin/com/strumenta/kolasu/model/Traversing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Traversing.kt
@@ -1,0 +1,21 @@
+package com.strumenta.kolasu.model
+
+import java.util.*
+
+/**
+ * The children, the children of those children, etc. The order is depth-first.
+ */
+fun Node.descendants(): Sequence<Node> {
+    val stack: Deque<Node> = ArrayDeque()
+    children.reversed().forEach { stack.push(it) }
+    return generateSequence {
+        if (stack.peek() == null) {
+            null
+        } else {
+            val next: Node = stack.pop()
+            val children: List<Node> = next.children
+            children.reversed().forEach { child -> stack.push(child) }
+            next
+        }
+    }
+}

--- a/src/main/kotlin/com/strumenta/kolasu/model/Traversing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Traversing.kt
@@ -8,6 +8,7 @@ import java.util.*
 typealias Stack<T> = Deque<T>
 
 fun <T> mutableStackOf(): Stack<T> = ArrayDeque()
+
 fun <T> Stack<T>.pushAll(elements: Collection<T>) {
     elements.reversed().forEach(this::push)
 }
@@ -113,7 +114,6 @@ fun Node.walkChildren(): Sequence<Node> {
         }
     }
 }
-
 
 /**
  * @param walker a function that generates a sequence of nodes. By default this is the depth-first "walk" method. For post-order traversal, take "walkLeavesFirst"

--- a/src/main/kotlin/com/strumenta/kolasu/model/Traversing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Traversing.kt
@@ -1,13 +1,14 @@
 package com.strumenta.kolasu.model
 
 import java.util.*
+import kotlin.reflect.KFunction1
 
 /**
- * The children, the children of those children, etc. The order is depth-first.
+ * @return walks the whole AST starting from this node, depth-first.
  */
-fun Node.descendants(): Sequence<Node> {
+fun Node.walk(): Sequence<Node> {
     val stack: Deque<Node> = ArrayDeque()
-    children.reversed().forEach { stack.push(it) }
+    stack.push(this)
     return generateSequence {
         if (stack.peek() == null) {
             null
@@ -18,4 +19,24 @@ fun Node.descendants(): Sequence<Node> {
             next
         }
     }
+}
+
+/**
+ * @return the sequence of nodes from this.parent all the way up to the root node.
+ * For this to work, assignParents() must have been called.
+ */
+fun Node.walkAncestors(): Sequence<Node> {
+    var currentNode: Node? = this
+    return generateSequence {
+        currentNode = currentNode!!.parent
+        currentNode
+    }
+}
+
+/**
+ * @param walker a function that generates a sequence of nodes. By default this is the depth-first "walk" method.
+ * @return walks the whole AST starting from the childnodes of this node.
+ */
+fun Node.walkDescendants(walker: KFunction1<Node, Sequence<Node>> = Node::walk): Sequence<Node> {
+    return walker.invoke(this).filter { node -> node != this }
 }

--- a/src/main/kotlin/com/strumenta/kolasu/model/Traversing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Traversing.kt
@@ -3,12 +3,13 @@ package com.strumenta.kolasu.model
 import java.util.*
 import kotlin.reflect.KFunction1
 
-fun <T> mutableStackOf(): Deque<T> = ArrayDeque()
-fun <T> Deque<T>.pushAll(elements: Collection<T>) {
+typealias Stack<T> = Deque<T>
+fun <T> mutableStackOf(): Stack<T> = ArrayDeque()
+fun <T> Stack<T>.pushAll(elements: Collection<T>) {
     elements.reversed().forEach(this::push)
 }
 
-fun <T> mutableStackOf(vararg elements: T): Deque<T> {
+fun <T> mutableStackOf(vararg elements: T): Stack<T> {
     val stack = mutableStackOf<T>()
     stack.pushAll(elements.asList())
     return stack
@@ -18,7 +19,7 @@ fun <T> mutableStackOf(vararg elements: T): Deque<T> {
  * @return walks the whole AST starting from this node, depth-first.
  */
 fun Node.walk(): Sequence<Node> {
-    val stack: Deque<Node> = mutableStackOf(this)
+    val stack: Stack<Node> = mutableStackOf(this)
     return generateSequence {
         if (stack.peek() == null) {
             null
@@ -34,8 +35,8 @@ fun Node.walk(): Sequence<Node> {
  * Performs a post-order (or leaves-first) node traversal starting with a given node.
  */
 fun Node.walkLeavesFirst(): Sequence<Node> {
-    val nodesStack: Deque<List<Node>> = mutableStackOf()
-    val cursorStack: Deque<Int> = ArrayDeque()
+    val nodesStack: Stack<List<Node>> = mutableStackOf()
+    val cursorStack: Stack<Int> = ArrayDeque()
     var done = false
 
     fun nextFromLevel(): Node {

--- a/src/main/kotlin/com/strumenta/kolasu/model/Traversing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Traversing.kt
@@ -3,7 +3,11 @@ package com.strumenta.kolasu.model
 import java.util.*
 import kotlin.reflect.KFunction1
 
+/**
+ * Some Kotlinization of Deques used as a stack.
+ */
 typealias Stack<T> = Deque<T>
+
 fun <T> mutableStackOf(): Stack<T> = ArrayDeque()
 fun <T> Stack<T>.pushAll(elements: Collection<T>) {
     elements.reversed().forEach(this::push)
@@ -98,7 +102,7 @@ fun Node.walkAncestors(): Sequence<Node> {
 }
 
 /**
- * @param walker a function that generates a sequence of nodes. By default this is the depth-first "walk" method.
+ * @param walker a function that generates a sequence of nodes. By default this is the depth-first "walk" method. For post-order traversal, take "walkLeavesFirst"
  * @return walks the whole AST starting from the childnodes of this node.
  */
 fun Node.walkDescendants(walker: KFunction1<Node, Sequence<Node>> = Node::walk): Sequence<Node> {

--- a/src/main/kotlin/com/strumenta/kolasu/model/Traversing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Traversing.kt
@@ -1,7 +1,6 @@
 package com.strumenta.kolasu.model
 
 import java.util.*
-import kotlin.reflect.KFunction1
 
 /**
  * Some Kotlinization of Deques used as a stack.
@@ -102,9 +101,24 @@ fun Node.walkAncestors(): Sequence<Node> {
 }
 
 /**
+ * @return all direct children of this node.
+ */
+fun Node.walkChildren(): Sequence<Node> {
+    return sequence {
+        containmentProperties.forEach { property ->
+            when (val value = property.get(this@walkChildren)) {
+                is Node -> yield(value as Node)
+                is Collection<*> -> value.forEach { if (it is Node) yield(it as Node) }
+            }
+        }
+    }
+}
+
+
+/**
  * @param walker a function that generates a sequence of nodes. By default this is the depth-first "walk" method. For post-order traversal, take "walkLeavesFirst"
  * @return walks the whole AST starting from the childnodes of this node.
  */
-fun Node.walkDescendants(walker: KFunction1<Node, Sequence<Node>> = Node::walk): Sequence<Node> {
+fun Node.walkDescendants(walker: (Node) -> Sequence<Node> = Node::walk): Sequence<Node> {
     return walker.invoke(this).filter { node -> node != this }
 }

--- a/src/test/kotlin/com/strumenta/kolasu/model/TraversingTest.kt
+++ b/src/test/kotlin/com/strumenta/kolasu/model/TraversingTest.kt
@@ -1,0 +1,30 @@
+package com.strumenta.kolasu.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+internal class TraversingTest {
+    class A(val a: List<Node>) : Node()
+    class B(val value: String) : Node()
+
+    @Test
+    fun depthFirst() {
+        val testCase = A(
+            listOf(
+                A(listOf(B("XYZ"))),
+                B("P"),
+                A(listOf(A(listOf(B("1"), B("2"), B("3"))))),
+                B("Q")
+            )
+        )
+        val result: String = testCase.descendants().map {
+            when (it) {
+                is A -> "[A]"
+                is B -> "[B ${it.value}]"
+                else -> fail("")
+            }
+        }.joinToString()
+        assertEquals("[A], [B XYZ], [B P], [A], [A], [B 1], [B 2], [B 3], [B Q]", result)
+    }
+}

--- a/src/test/kotlin/com/strumenta/kolasu/model/TraversingTest.kt
+++ b/src/test/kotlin/com/strumenta/kolasu/model/TraversingTest.kt
@@ -50,6 +50,12 @@ internal class TraversingTest {
     }
 
     @Test
+    fun walkLeavesFirst() {
+        val result: String = printSequence(testCase.walkLeavesFirst())
+        assertEquals("1, first, 2, 3, 4, 5, small, big, 6, root", result)
+    }
+
+    @Test
     fun walkDescendants() {
         val result: String = printSequence(testCase.walkDescendants())
         assertEquals("first, 1, 2, big, small, 3, 4, 5, 6", result)

--- a/src/test/kotlin/com/strumenta/kolasu/model/TraversingTest.kt
+++ b/src/test/kotlin/com/strumenta/kolasu/model/TraversingTest.kt
@@ -5,26 +5,61 @@ import kotlin.test.assertEquals
 import kotlin.test.fail
 
 internal class TraversingTest {
-    class A(val a: List<Node>) : Node()
-    class B(val value: String) : Node()
+    class Box(val name: String, val contents: List<Node>) : Node()
+    class Item(val name: String) : Node()
 
-    @Test
-    fun depthFirst() {
-        val testCase = A(
-            listOf(
-                A(listOf(B("XYZ"))),
-                B("P"),
-                A(listOf(A(listOf(B("1"), B("2"), B("3"))))),
-                B("Q")
-            )
-        )
-        val result: String = testCase.descendants().map {
+    private fun printSequence(sequence: Sequence<Node>): String {
+        return sequence.map {
             when (it) {
-                is A -> "[A]"
-                is B -> "[B ${it.value}]"
+                is Box -> it.name
+                is Item -> it.name
                 else -> fail("")
             }
         }.joinToString()
-        assertEquals("[A], [B XYZ], [B P], [A], [A], [B 1], [B 2], [B 3], [B Q]", result)
+    }
+
+    private val testCase = Box(
+        "root",
+        listOf(
+            Box(
+                "first",
+                listOf(
+                    Item("1")
+                )
+            ),
+            Item("2"),
+            Box(
+                "big",
+                listOf(
+                    Box(
+                        "small",
+                        listOf(
+                            Item("3"), Item("4"), Item("5")
+                        )
+                    )
+                )
+            ),
+            Item("6")
+        )
+    )
+
+    @Test
+    fun walkDepthFirst() {
+        val result: String = printSequence(testCase.walk())
+        assertEquals("root, first, 1, 2, big, small, 3, 4, 5, 6", result)
+    }
+
+    @Test
+    fun walkDescendants() {
+        val result: String = printSequence(testCase.walkDescendants())
+        assertEquals("first, 1, 2, big, small, 3, 4, 5, 6", result)
+    }
+
+    @Test
+    fun walkAncestors() {
+        testCase.assignParents()
+        val item4 = ((testCase.contents[2] as Box).contents[0] as Box).contents[1]
+        val result: String = printSequence(item4.walkAncestors())
+        assertEquals("small, big, root", result)
     }
 }


### PR DESCRIPTION
This is actually really, really powerful. I can do an in-place full tree transform like this:

```kotlin
    project.descendants().forEach { node ->
        when (node) {
            is HexadecimalLiteralExpr -> {
                val value = parseInt(node.rawValue.substring(1), 16)
                node.replace(ConstantValueExpr(value, guessLiteralNumberType(value)))
            }
        }
    }
```