### PR TITLE
Print private fields too.

### DIFF
--- a/src/main/kotlin/com/strumenta/kolasu/model/Printing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Printing.kt
@@ -2,12 +2,13 @@ package com.strumenta.kolasu.model
 
 import java.lang.reflect.ParameterizedType
 import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaType
 
 private const val indentBlock = "  "
 
 fun Node.relevantMemberProperties() = this.javaClass.kotlin.memberProperties
-    .filter { !it.name.startsWith("component") && it.name != "position" && it.name != "parent" }
+        .filter { !it.name.startsWith("component") && it.name != "position" && it.name != "parent" }
 
 fun Node.multilineString(indent: String = ""): String {
     val sb = StringBuffer()
@@ -27,6 +28,7 @@ fun Node.multilineString(indent: String = ""): String {
                     sb.append("$indent$indentBlock]\n")
                 }
             } else {
+                it.isAccessible = true
                 val value = it.get(this)
                 if (value is Node) {
                     sb.append("$indent$indentBlock${it.name} = [\n")

--- a/src/main/kotlin/com/strumenta/kolasu/model/Printing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Printing.kt
@@ -1,8 +1,8 @@
 package com.strumenta.kolasu.model
 
 import java.lang.reflect.ParameterizedType
+import kotlin.reflect.KVisibility.PUBLIC
 import kotlin.reflect.full.memberProperties
-import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaType
 
 private const val indentBlock = "  "
@@ -29,14 +29,15 @@ fun Node.multilineString(indent: String = ""): String {
                     sb.append("$indent$indentBlock]\n")
                 }
             } else {
-                property.isAccessible = true
-                val value = property.get(this)
-                if (value is Node) {
-                    sb.append("$indent$indentBlock${property.name} = [\n")
-                    sb.append(value.multilineString(indent + indentBlock + indentBlock))
-                    sb.append("$indent$indentBlock]\n")
-                } else {
-                    sb.append("$indent$indentBlock${property.name} = ${property.get(this)}\n")
+                if (property.visibility == PUBLIC) {
+                    val value = property.get(this)
+                    if (value is Node) {
+                        sb.append("$indent$indentBlock${property.name} = [\n")
+                        sb.append(value.multilineString(indent + indentBlock + indentBlock))
+                        sb.append("$indent$indentBlock]\n")
+                    } else {
+                        sb.append("$indent$indentBlock${property.name} = ${property.get(this)}\n")
+                    }
                 }
             }
         }

--- a/src/test/kotlin/com/strumenta/kolasu/model/PrintingTest.kt
+++ b/src/test/kotlin/com/strumenta/kolasu/model/PrintingTest.kt
@@ -56,20 +56,6 @@ class PrintingTest {
 """Add {
   left = [
     Sub {
-      left = [
-        Number {
-          value = 3
-          parseTreeNode = null
-          specifiedPosition = null
-        } // Number
-      ]
-      right = [
-        Number {
-          value = 9
-          parseTreeNode = null
-          specifiedPosition = null
-        } // Number
-      ]
       parseTreeNode = null
       specifiedPosition = null
     } // Sub

--- a/src/test/kotlin/com/strumenta/kolasu/model/PrintingTest.kt
+++ b/src/test/kotlin/com/strumenta/kolasu/model/PrintingTest.kt
@@ -6,6 +6,7 @@ import org.junit.Test as test
 abstract class Expr : Node()
 class Number(val value: Int) : Expr()
 class Add(val left: Expr, val right: Expr) : Expr()
+class Sub(private val left: Expr, private val right: Expr) : Expr()
 
 class PrintingTest {
     @test
@@ -32,6 +33,46 @@ class PrintingTest {
       parseTreeNode = null
       specifiedPosition = null
     } // Add
+  ]
+  right = [
+    Number {
+      value = 1
+      parseTreeNode = null
+      specifiedPosition = null
+    } // Number
+  ]
+  parseTreeNode = null
+  specifiedPosition = null
+} // Add
+""",
+            ast.multilineString()
+        )
+    }
+
+    @test
+    fun privateFieldsGetPrintedToo() {
+        val ast = Add(Sub(Number(3), Number(9)), Number(1))
+        assertEquals(
+"""Add {
+  left = [
+    Sub {
+      left = [
+        Number {
+          value = 3
+          parseTreeNode = null
+          specifiedPosition = null
+        } // Number
+      ]
+      right = [
+        Number {
+          value = 9
+          parseTreeNode = null
+          specifiedPosition = null
+        } // Number
+      ]
+      parseTreeNode = null
+      specifiedPosition = null
+    } // Sub
   ]
   right = [
     Number {


### PR DESCRIPTION
Quick PR: let the printer print private fields too. Fixes #10, but possibly not as desired.