### PR TITLE
Insert before after remove

### DIFF
--- a/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -303,6 +303,7 @@ fun Node.replaceWithSeveral(oldNode: Node, newNodes: List<Node>) {
             }
         }
     }
+    throw IllegalStateException("Did not find $oldNode in any MutableList in $this. Replace failed.")
 }
 
 /**

--- a/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -29,7 +29,7 @@ fun Node.assignParents() {
 }
 
 /**
- * Recursively execute "operation" on this node, and all nodes below this node.
+ * Recursively execute [operation] on [this] node, and all nodes below this node.
  * @param walker the function that generates the nodes to operate on in the desired sequence.
  */
 fun Node.processNodes(operation: (Node) -> Unit, walker: KFunction1<Node, Sequence<Node>> = Node::walk) {
@@ -61,14 +61,14 @@ private fun providesNodes(kclass: KClass<*>?): Boolean {
 }
 
 /**
- * @return can this class be considered an AST node?
+ * @return can [this] class be considered an AST node?
  */
 fun KClass<*>.isANode(): Boolean {
     return this.isSubclassOf(Node::class) || this.isMarkedAsNodeType()
 }
 
 /**
- * @return is this class annotated with NodeType?
+ * @return is [this] class annotated with NodeType?
  */
 fun KClass<*>.isMarkedAsNodeType(): Boolean {
     return this.annotations.any { it.annotationClass == NodeType::class }
@@ -108,14 +108,14 @@ fun Node.processProperties(
 
 /**
  * @param walker the function that generates the nodes to operate on in the desired sequence.
- * @return the first node in the AST for which the predicate is true. Null if none are found.
+ * @return the first node in the AST for which the [predicate] is true. Null if none are found.
  */
 fun Node.find(predicate: (Node) -> Boolean, walker: KFunction1<Node, Sequence<Node>> = Node::walk): Node? {
     return walker.invoke(this).find(predicate)
 }
 
 /**
- * Recursively execute "operation" on this node, and all nodes below this node that extend klass.
+ * Recursively execute [operation] on this node, and all nodes below this node that extend [klass].
  * @param walker the function that generates the nodes to operate on in the desired sequence.
  */
 fun <T : Node> Node.processNodesOfType(klass: Class<T>, operation: (T) -> Unit, walker: KFunction1<Node, Sequence<Node>> = Node::walk) {
@@ -124,15 +124,15 @@ fun <T : Node> Node.processNodesOfType(klass: Class<T>, operation: (T) -> Unit, 
 
 /**
  * @param walker the function that generates the nodes to operate on in the desired sequence.
- * @return all nodes in this AST (sub)tree that are instances of, or extend klass.
+ * @return all nodes in this AST (sub)tree that are instances of, or extend [klass].
  */
 fun <T : Node> Node.collectByType(klass: Class<T>, walker: KFunction1<Node, Sequence<Node>> = Node::walk): List<T> {
     return walker.invoke(this).filterIsInstance(klass).toList()
 }
 
 /**
- * Recursively execute "operation" on this node, and all nodes below this node.
- * Every node is informed about its parent node. (But not about the parent's parent!)
+ * Recursively execute [operation] on this node, and all nodes below this node.
+ * Every node is informed about its [parent] node. (But not about the parent's parent!)
  */
 fun Node.processConsideringDirectParent(operation: (Node, Node?) -> Unit, parent: Node? = null) {
     operation(this, parent)
@@ -146,7 +146,7 @@ fun Node.processConsideringDirectParent(operation: (Node, Node?) -> Unit, parent
 }
 
 /**
- * @return all direct children of this node.
+ * @return all direct children of [this] node.
  */
 val Node.children: List<Node>
     get() {
@@ -272,12 +272,45 @@ fun Node.mapTree(operation: (Node) -> Node): Node {
 }
 
 /**
- * Replace this node with "other" (by modifying the children of the parent node.)
- * For this to work, assignParents() must have been called.
+ * Replace [this] node with [other] (by modifying the children of the parent node.)
+ * For this to work, [Node.assignParents] must have been called.
  */
 fun Node.replaceWith(other: Node) {
     if (this.parent == null) {
         throw IllegalStateException("Parent not set")
     }
     this.parent!!.transformTree { if (it == this) other else it }
+}
+
+/**
+ * Looks for [oldNode] in the lists of nodes in this node.
+ * When found, it is removed, and in its place the [newNodes] are inserted.
+ */
+@Suppress("UNCHECKED_CAST") // assumption: a MutableList with a Node in it is a MutableList<Node>
+fun Node.replaceWithSeveral(oldNode: Node, newNodes: List<Node>) {
+    relevantMemberProperties().forEach { property ->
+        when (val value = property.get(this)) {
+            is MutableList<*> -> {
+                for (i in 0 until value.size) {
+                    if (value[i] == oldNode) {
+                        val nodeList = value as MutableList<Node>
+                        nodeList.removeAt(i)
+                        nodeList.addAll(i, newNodes)
+                        newNodes.forEach { node -> node.parent = this@replaceWithSeveral }
+                        return
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Replaces this node with any amount of other nodes.
+ * <p/>Looks for [this] in the lists of nodes in the parent node.
+ * When found, [this] is removed, and in its place [newNodes] are inserted.
+ * For this to work, [Node.assignParents] must have been called.
+ */
+fun Node.replaceWithSeveral(newNodes: List<Node>) {
+    (parent ?: throw IllegalStateException("Parent not set")).replaceWithSeveral(this, newNodes)
 }

--- a/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -146,7 +146,7 @@ fun Node.processConsideringDirectParent(operation: (Node, Node?) -> Unit, parent
 }
 
 /**
- * @return all direct children of [this] node.
+ * @return all direct children of this node.
  */
 val Node.children: List<Node>
     get() {
@@ -286,32 +286,119 @@ fun Node.replaceWith(other: Node) {
  * Looks for [oldNode] in the lists of nodes in this node.
  * When found, it is removed, and in its place the [newNodes] are inserted.
  */
-@Suppress("UNCHECKED_CAST") // assumption: a MutableList with a Node in it is a MutableList<Node>
 fun Node.replaceWithSeveral(oldNode: Node, newNodes: List<Node>) {
+    findMutableListContainingChild(oldNode) { nodeList, index ->
+        nodeList.replaceWithSeveral(index, newNodes)
+        oldNode.parent = null
+        newNodes.forEach { node -> node.parent = this }
+    }
+}
+
+/**
+ * Looks for [targetNode] in the lists of nodes in this node.
+ * When found, it is removed.
+ */
+fun Node.remove(targetNode: Node) {
+    findMutableListContainingChild(targetNode) { nodeList, index ->
+        nodeList.removeAt(index)
+        targetNode.parent = null
+    }
+}
+
+/**
+ * Looks for [targetNode] in the lists of nodes in this node.
+ * When found, [newNodes] are inserted before it.
+ */
+fun Node.addSeveralBefore(targetNode: Node, newNodes: List<Node>) {
+    findMutableListContainingChild(targetNode) { nodeList, index ->
+        nodeList.addSeveralBefore(index, newNodes)
+        newNodes.forEach { node -> node.parent = this }
+    }
+}
+
+/**
+ * Looks for [targetNode] in the lists of nodes in this node.
+ * When found, [newNodes] are inserted after it.
+ */
+fun Node.addSeveralAfter(targetNode: Node, newNodes: List<Node>) {
+    findMutableListContainingChild(targetNode) { nodeList, index ->
+        nodeList.addSeveralAfter(index, newNodes)
+        newNodes.forEach { node -> node.parent = this }
+    }
+}
+
+/**
+ * Supports functions that manipulate a list of child nodes by finding [targetNode] in the [MutableList]s of nodes contained in [this] node.
+ */
+@Suppress("UNCHECKED_CAST") // assumption: a MutableList with a Node in it is a MutableList<Node>
+private fun Node.findMutableListContainingChild(targetNode: Node, whenFoundDo: (nodeList: MutableList<Node>, index: Int) -> Unit) {
     relevantMemberProperties().forEach { property ->
         when (val value = property.get(this)) {
             is MutableList<*> -> {
                 for (i in 0 until value.size) {
-                    if (value[i] == oldNode) {
-                        val nodeList = value as MutableList<Node>
-                        nodeList.removeAt(i)
-                        nodeList.addAll(i, newNodes)
-                        newNodes.forEach { node -> node.parent = this@replaceWithSeveral }
+                    if (value[i] == targetNode) {
+                        whenFoundDo(value as MutableList<Node>, i)
                         return
                     }
                 }
             }
         }
     }
-    throw IllegalStateException("Did not find $oldNode in any MutableList in $this. Replace failed.")
+    throw IllegalStateException("Did not find $targetNode in any MutableList in $this.")
 }
 
 /**
- * Replaces this node with any amount of other nodes.
+ * Replaces [this] node with any amount of other nodes if it is in a [MutableList].
  * <p/>Looks for [this] in the lists of nodes in the parent node.
  * When found, [this] is removed, and in its place [newNodes] are inserted.
  * For this to work, [Node.assignParents] must have been called.
  */
 fun Node.replaceWithSeveral(newNodes: List<Node>) {
     parent?.replaceWithSeveral(this, newNodes) ?: throw IllegalStateException("Parent not set")
+}
+
+/**
+ * Inserts the [newNodes] before [this] node if it is in a [MutableList].
+ * For this to work, [Node.assignParents] must have been called.
+ */
+fun Node.addSeveralBefore(newNodes: List<Node>) {
+    parent?.addSeveralBefore(this, newNodes) ?: throw IllegalStateException("Parent not set")
+}
+
+/**
+ * Inserts the [newNodes] after [this] node if it is in a [MutableList].
+ * For this to work, [Node.assignParents] must have been called.
+ */
+fun Node.addSeveralAfter(newNodes: List<Node>) {
+    parent?.addSeveralAfter(this, newNodes) ?: throw IllegalStateException("Parent not set")
+}
+
+/**
+ * Removes [this] node from the parent if it is in a [MutableList].
+ * For this to work, [Node.assignParents] must have been called.
+ */
+fun Node.remove() {
+    parent?.remove(this) ?: throw IllegalStateException("Parent not set")
+}
+
+/**
+ * Replaces the element at [index] with [replacements].
+ */
+fun <T> MutableList<T>.replaceWithSeveral(index: Int, replacements: List<T>) {
+    removeAt(index)
+    addAll(index, replacements)
+}
+
+/**
+ * Replaces the element at [index] with [additions].
+ */
+fun <T> MutableList<T>.addSeveralBefore(index: Int, additions: List<T>) {
+    addAll(index, additions)
+}
+
+/**
+ * Replaces the element at [index] with [additions].
+ */
+fun <T> MutableList<T>.addSeveralAfter(index: Int, additions: List<T>) {
+    addAll(index + 1, additions)
 }

--- a/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -285,6 +285,7 @@ fun Node.replaceWith(other: Node) {
 /**
  * Looks for [oldNode] in the lists of nodes in this node.
  * When found, it is removed, and in its place the [newNodes] are inserted.
+ * When not found, an [IllegalStateException] is thrown.
  */
 fun Node.replaceWithSeveral(oldNode: Node, newNodes: List<Node>) {
     findMutableListContainingChild(oldNode) { nodeList, index ->
@@ -297,8 +298,9 @@ fun Node.replaceWithSeveral(oldNode: Node, newNodes: List<Node>) {
 /**
  * Looks for [targetNode] in the lists of nodes in this node.
  * When found, it is removed.
+ * When not found, an [IllegalStateException] is thrown.
  */
-fun Node.remove(targetNode: Node) {
+fun Node.removeFromList(targetNode: Node) {
     findMutableListContainingChild(targetNode) { nodeList, index ->
         nodeList.removeAt(index)
         targetNode.parent = null
@@ -308,6 +310,7 @@ fun Node.remove(targetNode: Node) {
 /**
  * Looks for [targetNode] in the lists of nodes in this node.
  * When found, [newNodes] are inserted before it.
+ * When not found, an [IllegalStateException] is thrown.
  */
 fun Node.addSeveralBefore(targetNode: Node, newNodes: List<Node>) {
     findMutableListContainingChild(targetNode) { nodeList, index ->
@@ -319,6 +322,7 @@ fun Node.addSeveralBefore(targetNode: Node, newNodes: List<Node>) {
 /**
  * Looks for [targetNode] in the lists of nodes in this node.
  * When found, [newNodes] are inserted after it.
+ * When not found, an [IllegalStateException] is thrown.
  */
 fun Node.addSeveralAfter(targetNode: Node, newNodes: List<Node>) {
     findMutableListContainingChild(targetNode) { nodeList, index ->
@@ -377,8 +381,8 @@ fun Node.addSeveralAfter(newNodes: List<Node>) {
  * Removes [this] node from the parent if it is in a [MutableList].
  * For this to work, [Node.assignParents] must have been called.
  */
-fun Node.remove() {
-    parent?.remove(this) ?: throw IllegalStateException("Parent not set")
+fun Node.removeFromList() {
+    parent?.removeFromList(this) ?: throw IllegalStateException("Parent not set")
 }
 
 /**

--- a/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -313,5 +313,5 @@ fun Node.replaceWithSeveral(oldNode: Node, newNodes: List<Node>) {
  * For this to work, [Node.assignParents] must have been called.
  */
 fun Node.replaceWithSeveral(newNodes: List<Node>) {
-    (parent ?: throw IllegalStateException("Parent not set")).replaceWithSeveral(this, newNodes)
+    parent?.replaceWithSeveral(this, newNodes) ?: throw IllegalStateException("Parent not set")
 }

--- a/src/test/kotlin/com/strumenta/kolasu/model/ProcessingTest.kt
+++ b/src/test/kotlin/com/strumenta/kolasu/model/ProcessingTest.kt
@@ -3,6 +3,7 @@ package com.strumenta.kolasu.model
 import java.lang.UnsupportedOperationException
 import java.util.LinkedList
 import kotlin.test.assertEquals
+import kotlin.test.assertSame
 import org.junit.Test as test
 
 data class A(val s: String) : Node()
@@ -37,7 +38,8 @@ class ProcessingTest {
         a1.replaceWith(a2)
     }
 
-    @test fun replaceSingle() {
+    @test
+    fun replaceSingle() {
         val a1 = AW("1")
         val a2 = AW("2")
         val b = BW(a1, LinkedList())
@@ -46,7 +48,8 @@ class ProcessingTest {
         assertEquals("2", b.a.s)
     }
 
-    @test fun replaceInList() {
+    @test
+    fun replaceInList() {
         val a1 = AW("1")
         val a2 = AW("2")
         val a3 = AW("3")
@@ -57,7 +60,8 @@ class ProcessingTest {
         assertEquals("4", b.manyAs[0].s)
     }
 
-    @test fun replaceSeveralInList() {
+    @test
+    fun replaceSeveralInList() {
         val a1 = AW("1")
         val a2 = AW("2")
         val a3 = AW("3")
@@ -70,7 +74,8 @@ class ProcessingTest {
         assertEquals("3", b.manyAs[2].s)
     }
 
-    @test fun replaceSeveralInListInParent() {
+    @test
+    fun replaceSeveralInListInParent() {
         val a1 = AW("1")
         val a2 = AW("2")
         val a3 = AW("3")
@@ -105,5 +110,54 @@ class ProcessingTest {
         val b = CW(a1, mutableSetOf(a2, a3))
         b.assignParents()
         a2.replaceWith(a4)
+    }
+
+    @test
+    fun addSeveralBeforeInListInParent() {
+        val notInList = AW("x")
+        val existing1 = AW("e1")
+        val existing2 = AW("e2")
+        val before1 = AW("b1")
+        val before2 = AW("b2")
+        val parentNode = BW(notInList, mutableListOf(existing1, existing2))
+        parentNode.assignParents()
+        existing1.addSeveralBefore(listOf(before1))
+        existing2.addSeveralBefore(listOf(before2))
+
+        assertSame(before1, parentNode.manyAs[0])
+        assertSame(existing1, parentNode.manyAs[1])
+        assertSame(before2, parentNode.manyAs[2])
+        assertSame(existing2, parentNode.manyAs[3])
+    }
+
+    @test
+    fun addSeveralAfterInListInParent() {
+        val notInList = AW("x")
+        val existing1 = AW("e1")
+        val existing2 = AW("e2")
+        val after1 = AW("a1")
+        val after2 = AW("a2")
+        val parentNode = BW(notInList, mutableListOf(existing1, existing2))
+        parentNode.assignParents()
+        existing1.addSeveralAfter(listOf(after1))
+        existing2.addSeveralAfter(listOf(after2))
+
+        assertSame(existing1, parentNode.manyAs[0])
+        assertSame(after1, parentNode.manyAs[1])
+        assertSame(existing2, parentNode.manyAs[2])
+        assertSame(after2, parentNode.manyAs[3])
+    }
+
+    @test
+    fun removeInListInParent() {
+        val notInList = AW("x")
+        val existing1 = AW("e1")
+        val existing2 = AW("e2")
+        val parentNode = BW(notInList, mutableListOf(existing1, existing2))
+        parentNode.assignParents()
+        existing2.remove()
+
+        assertSame(existing1, parentNode.manyAs[0])
+        assertEquals(1, parentNode.manyAs.size)
     }
 }

--- a/src/test/kotlin/com/strumenta/kolasu/model/ProcessingTest.kt
+++ b/src/test/kotlin/com/strumenta/kolasu/model/ProcessingTest.kt
@@ -155,7 +155,7 @@ class ProcessingTest {
         val existing2 = AW("e2")
         val parentNode = BW(notInList, mutableListOf(existing1, existing2))
         parentNode.assignParents()
-        existing2.remove()
+        existing2.removeFromList()
 
         assertSame(existing1, parentNode.manyAs[0])
         assertEquals(1, parentNode.manyAs.size)

--- a/src/test/kotlin/com/strumenta/kolasu/model/ProcessingTest.kt
+++ b/src/test/kotlin/com/strumenta/kolasu/model/ProcessingTest.kt
@@ -84,6 +84,18 @@ class ProcessingTest {
         assertEquals("3", b.manyAs[2].s)
     }
 
+    @test(expected = IllegalStateException::class)
+    fun replaceSeveralInListInParentButTheNodeToReplaceIsMissing() {
+        val a1 = AW("1")
+        val a2 = AW("2")
+        val a3 = AW("3")
+        val a4 = AW("4")
+        val a5 = AW("5")
+        val b = BW(a1, mutableListOf(a2, a3))
+        b.assignParents()
+        a1.replaceWithSeveral(listOf(a4, a5))
+    }
+
     @test(expected = UnsupportedOperationException::class)
     fun replaceInSet() {
         val a1 = AW("1")

--- a/src/test/kotlin/com/strumenta/kolasu/model/ProcessingTest.kt
+++ b/src/test/kotlin/com/strumenta/kolasu/model/ProcessingTest.kt
@@ -57,6 +57,33 @@ class ProcessingTest {
         assertEquals("4", b.manyAs[0].s)
     }
 
+    @test fun replaceSeveralInList() {
+        val a1 = AW("1")
+        val a2 = AW("2")
+        val a3 = AW("3")
+        val a4 = AW("4")
+        val a5 = AW("5")
+        val b = BW(a1, mutableListOf(a2, a3))
+        b.replaceWithSeveral(a2, listOf(a4, a5))
+        assertEquals("4", b.manyAs[0].s)
+        assertEquals("5", b.manyAs[1].s)
+        assertEquals("3", b.manyAs[2].s)
+    }
+
+    @test fun replaceSeveralInListInParent() {
+        val a1 = AW("1")
+        val a2 = AW("2")
+        val a3 = AW("3")
+        val a4 = AW("4")
+        val a5 = AW("5")
+        val b = BW(a1, mutableListOf(a2, a3))
+        b.assignParents()
+        a2.replaceWithSeveral(listOf(a4, a5))
+        assertEquals("4", b.manyAs[0].s)
+        assertEquals("5", b.manyAs[1].s)
+        assertEquals("3", b.manyAs[2].s)
+    }
+
     @test(expected = UnsupportedOperationException::class)
     fun replaceInSet() {
         val a1 = AW("1")


### PR DESCRIPTION
This builds on #33, adding a few functions that make manipulation of lists of nodes complete as far as I can see.

There are sets of...
- functions that say "remove/addbefore/etc. THIS node" which use:
- functions that say "remove/addbefore/etc. the parameter node, which is somewhere in a list in THIS"
- functions that say "remove/addbefore/etc. the parameter item from THIS MutableList"

Possibly the second set of functions is redundant or confusing.

The function that looks for the node in all of the mutable lists in a node has been generalized.