### PR TITLE
Adding interfaces for common AST elements

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
@@ -1,0 +1,13 @@
+package com.strumenta.kolasu.model
+
+@NodeType
+interface Statement
+
+@NodeType
+interface Expression
+
+/**
+ * This should be used for definitions of classes, interfaces, structures
+ */
+@NodeType
+interface EntityDeclaration

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/Metamodel.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/Metamodel.kt
@@ -84,7 +84,11 @@ val ResultHandler = KolasuClassHandler(Result::class, KOLASU_METAMODEL.getEClass
 
 val StatementHandler = KolasuClassHandler(Statement::class, KOLASU_METAMODEL.getEClass("Statement"))
 val ExpressionHandler = KolasuClassHandler(Expression::class, KOLASU_METAMODEL.getEClass("Expression"))
-val EntityDeclarationHandler = KolasuClassHandler(EntityDeclaration::class, KOLASU_METAMODEL.getEClass("EntityDeclaration"))
+val EntityDeclarationHandler = KolasuClassHandler(
+    EntityDeclaration::class,
+    KOLASU_METAMODEL
+        .getEClass("EntityDeclaration")
+)
 
 val StringHandler = KolasuDataTypeHandler(String::class, EcorePackage.eINSTANCE.eString)
 val CharHandler = KolasuDataTypeHandler(Char::class, EcorePackage.eINSTANCE.eChar)

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/Metamodel.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/Metamodel.kt
@@ -82,6 +82,10 @@ val PossiblyNamedHandler = KolasuClassHandler(PossiblyNamed::class, KOLASU_METAM
 val ReferenceByNameHandler = KolasuClassHandler(ReferenceByName::class, KOLASU_METAMODEL.getEClass("ReferenceByName"))
 val ResultHandler = KolasuClassHandler(Result::class, KOLASU_METAMODEL.getEClass("Result"))
 
+val StatementHandler = KolasuClassHandler(Statement::class, KOLASU_METAMODEL.getEClass("Statement"))
+val ExpressionHandler = KolasuClassHandler(Expression::class, KOLASU_METAMODEL.getEClass("Expression"))
+val EntityDeclarationHandler = KolasuClassHandler(EntityDeclaration::class, KOLASU_METAMODEL.getEClass("EntityDeclaration"))
+
 val StringHandler = KolasuDataTypeHandler(String::class, EcorePackage.eINSTANCE.eString)
 val CharHandler = KolasuDataTypeHandler(Char::class, EcorePackage.eINSTANCE.eChar)
 val BooleanHandler = KolasuDataTypeHandler(Boolean::class, EcorePackage.eINSTANCE.eBoolean)

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
@@ -66,6 +66,10 @@ class MetamodelBuilder(packageName: String, nsURI: String, nsPrefix: String, res
         eclassTypeHandlers.add(PossiblyNamedHandler)
         eclassTypeHandlers.add(ReferenceByNameHandler)
         eclassTypeHandlers.add(ResultHandler)
+
+        eclassTypeHandlers.add(StatementHandler)
+        eclassTypeHandlers.add(ExpressionHandler)
+        eclassTypeHandlers.add(EntityDeclarationHandler)
     }
 
     /**

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/kolasu_metamodel.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/kolasu_metamodel.kt
@@ -31,10 +31,7 @@ private fun createKolasuMetamodel(): EPackage {
     ePackage.eClassifiers.add(bigIntegerDT)
 
     val stringDT = EcorePackage.eINSTANCE.eString
-    val charDT = EcorePackage.eINSTANCE.eChar
     val intDT = EcorePackage.eINSTANCE.eInt
-    val longDT = EcorePackage.eINSTANCE.eLong
-    val booleanDT = EcorePackage.eINSTANCE.eBoolean
 
     val localDate = ePackage.createEClass("LocalDate").apply {
         addAttribute("year", intDT, 1, 1)
@@ -67,6 +64,16 @@ private fun createKolasuMetamodel(): EPackage {
         addContainment("position", position, 0, 1)
         addContainment("destination", position, 0, 1)
         addReference("origin", origin, 0, 1)
+    }
+
+    ePackage.createEClass("Statement").apply {
+        this.isInterface = true
+    }
+    ePackage.createEClass("Expression").apply {
+        this.isInterface = true
+    }
+    ePackage.createEClass("EntityDeclaration").apply {
+        this.isInterface = true
     }
 
     val issueType = EcoreFactory.eINSTANCE.createEEnum()

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/ModelTest.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/ModelTest.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 data class NodeFoo(val name: String) : Node()
-class MyRoot(val foo: Int) : Node(), Statement {}
+class MyRoot(val foo: Int) : Node(), Statement
 
 class ModelTest {
 
@@ -168,5 +168,4 @@ class ModelTest {
         println(eo1.eClass().eSuperTypes)
         assertEquals(setOf("ASTNode", "Statement"), eo1.eClass().eSuperTypes.map { it.name }.toSet())
     }
-
 }

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/ModelTest.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/ModelTest.kt
@@ -3,12 +3,14 @@ package com.strumenta.kolasu.emf
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Point
 import com.strumenta.kolasu.model.Position
+import com.strumenta.kolasu.model.Statement
 import com.strumenta.kolasu.model.withPosition
 import org.eclipse.emf.common.util.EList
 import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.emf.ecore.resource.impl.ResourceImpl
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.emfcloud.jackson.resource.JsonResourceFactory
 import org.junit.Test
@@ -19,6 +21,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 data class NodeFoo(val name: String) : Node()
+class MyRoot(val foo: Int) : Node(), Statement {}
 
 class ModelTest {
 
@@ -140,4 +143,30 @@ class ModelTest {
         assertEquals(7, endEO.eGet("line"))
         assertEquals(4, endEO.eGet("column"))
     }
+
+    @Test
+    fun statementIsConsideredCorrectlyInMetamodel() {
+        val mmb = MetamodelBuilder("com.strumenta.kolasu.emf", "http://foo.com", "foo")
+        mmb.provideClass(MyRoot::class)
+        val ePackage = mmb.generate()
+        assertEquals(1, ePackage.eClassifiers.size)
+        val ec = ePackage.eClassifiers[0] as EClass
+        assertEquals("MyRoot", ec.name)
+        assertEquals(setOf("ASTNode", "Statement"), ec.eSuperTypes.map { it.name }.toSet())
+    }
+
+    @Test
+    fun statementIsSerializedCorrectly() {
+        val mmb = MetamodelBuilder("com.strumenta.kolasu.emf", "http://foo.com", "foo")
+        mmb.provideClass(MyRoot::class)
+        val ePackage = mmb.generate()
+
+        val res = ResourceImpl()
+        res.contents.add(ePackage)
+        val r1 = MyRoot(124)
+        val eo1 = r1.toEObject(res)
+        println(eo1.eClass().eSuperTypes)
+        assertEquals(setOf("ASTNode", "Statement"), eo1.eClass().eSuperTypes.map { it.name }.toSet())
+    }
+
 }

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
@@ -379,6 +379,18 @@ class EMFCLIToolTest {
       }
     } ]
   }, {
+    "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+    "name" : "Statement",
+    "interface" : true
+  }, {
+    "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+    "name" : "Expression",
+    "interface" : true
+  }, {
+    "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+    "name" : "EntityDeclaration",
+    "interface" : true
+  }, {
     "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EEnum",
     "name" : "IssueType",
     "eLiterals" : [ {


### PR DESCRIPTION
For now, we introduce only Statement, Expression, and EntityDeclaration (for classes, interfaces, structs).
They are also added in the Kolasu metamodel.