### PR TITLE
Implementing Node.toString

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
@@ -132,6 +132,10 @@ open class Node() : Origin, Destination {
 
     @Internal
     var destination: Destination? = null
+
+    override fun toString(): String {
+        return "${this.nodeType}(${properties.joinToString(", ") { "${it.name}=${it.valueToString()}" }})"
+    }
 }
 
 fun <N : Node> N.withPosition(position: Position?): N {

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
@@ -133,7 +133,12 @@ open class Node() : Origin, Destination {
     @Internal
     var destination: Destination? = null
 
-    override fun toString(): String {
+    /**
+     * This must be final because otherwise data classes extending this will automatically generate
+     * their own implementation. If Link properties are present it could lead to stack overflows in case
+     * of circular graphs.
+     */
+    final override fun toString(): String {
         return "${this.nodeType}(${properties.joinToString(", ") { "${it.name}=${it.valueToString()}" }})"
     }
 }

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Reflection.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Reflection.kt
@@ -41,6 +41,24 @@ data class PropertyDescription(
     val multiplicity: Multiplicity,
     val value: Any?
 ) {
+    fun valueToString(): String {
+        if (value == null) {
+            return "null"
+        }
+        return if (provideNodes) {
+            if (multiplicity == Multiplicity.MANY) {
+                "[${(value as Collection<Node>).joinToString(",") { it.nodeType }}]"
+            } else {
+                "${(value as Node).nodeType}(...)"
+            }
+        } else {
+            if (multiplicity == Multiplicity.MANY) {
+                "[${(value as Collection<*>).joinToString(",") { it.toString() }}]"
+            } else {
+                value.toString()
+            }
+        }
+    }
 
     val multiple: Boolean
         get() = multiplicity == Multiplicity.MANY

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/rpgast/data_definitions.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/rpgast/data_definitions.kt
@@ -221,11 +221,7 @@ class InStatementDataDefinition(
     override val type: Type,
     val specifiedPosition: Position? = null,
     val initializationValue: Expression? = null
-) : AbstractDataDefinition(name, type, specifiedPosition) {
-    override fun toString(): String {
-        return "InStatementDataDefinition name=$name, type=$type, specifiedPosition=$specifiedPosition"
-    }
-}
+) : AbstractDataDefinition(name, type, specifiedPosition)
 
 /**
  * Encoding/Decoding a binary value for a data structure


### PR DESCRIPTION
This implementation avoid the risk of stack overflow in case of nodes using links and presenting circular graphs.

The drawback is that the implementation must be final, otherwise the auto-generated toString of data classes prevail.