### PR TITLE
Node printer overrider

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/codegen/ASTCodeGenerator.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/codegen/ASTCodeGenerator.kt
@@ -15,6 +15,7 @@ import kotlin.reflect.KClass
  */
 abstract class ASTCodeGenerator<R : Node> {
     protected val nodePrinters: MutableMap<KClass<*>, NodePrinter> = HashMap<KClass<*>, NodePrinter>()
+    var nodePrinterOverrider: (node: Node) -> NodePrinter? = { _ -> null }
 
     protected abstract fun registerRecordPrinters()
 
@@ -28,10 +29,10 @@ abstract class ASTCodeGenerator<R : Node> {
         }
     }
 
-    fun printToString(root: R): String {
-        val o = PrinterOutput(nodePrinters)
-        o.print(root)
-        return o.text()
+    fun printToString(ast: R): String {
+        return PrinterOutput(this.nodePrinters, nodePrinterOverrider)
+            .apply { this.print(ast) }
+            .text()
     }
 
     fun printToFile(root: R, file: File) {

--- a/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
@@ -93,7 +93,8 @@ class PrinterOutput(
             return
         }
         print(prefix)
-        val printer = nodePrinterOverrider(ast) ?: nodePrinters[ast::class] ?: throw java.lang.IllegalArgumentException("Unable to print $ast")
+        val printer = nodePrinterOverrider(ast) ?: nodePrinters[ast::class]
+            ?: throw java.lang.IllegalArgumentException("Unable to print $ast")
         associate(ast) {
             printer.print(this, ast)
         }

--- a/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
@@ -17,7 +17,10 @@ fun interface NodePrinter {
  * This provides a mechanism to generate code tracking indentation, handling lists, and providing other facilities.
  * This is used in the implementation of NodePrinter and in ASTCodeGenerator.
  */
-class PrinterOutput(private val nodePrinters: Map<KClass<*>, NodePrinter>) {
+class PrinterOutput(
+    private val nodePrinters: Map<KClass<*>, NodePrinter>,
+    private var nodePrinterOverrider: (node: Node) -> NodePrinter? = { _ -> null }
+) {
     private val sb = StringBuilder()
     private var currentPoint = START_POINT
     private var indentationLevel = 0
@@ -85,34 +88,41 @@ class PrinterOutput(private val nodePrinters: Map<KClass<*>, NodePrinter>) {
         print(postfix)
     }
 
-    fun print(ast: Node?, prefix: String? = null, postfix: String? = null) {
+    fun print(ast: Node?, prefix: String = "", postfix: String = "") {
         if (ast == null) {
             return
         }
-        prefix?.let { print(it) }
-        val printer = nodePrinters[ast::class] ?: throw java.lang.IllegalArgumentException("Unable to print $ast")
+        print(prefix)
+        val printer = nodePrinterOverrider(ast) ?: nodePrinters[ast::class] ?: throw java.lang.IllegalArgumentException("Unable to print $ast")
         associate(ast) {
             printer.print(this, ast)
         }
-        postfix?.let { print(it) }
+        print(postfix)
     }
 
     fun println(ast: Node?, prefix: String = "", postfix: String = "") {
         print(ast, prefix, postfix + "\n")
     }
 
+    fun printEmptyLine() {
+        println()
+        println()
+    }
+
     fun indent() {
         indentationLevel++
     }
+
     fun dedent() {
         indentationLevel--
     }
+
     fun associate(ast: Node, generation: PrinterOutput.() -> Unit) {
         val startPoint = currentPoint
         generation()
         val endPoint = currentPoint
         val nodePositionInGeneratedCode = Position(startPoint, endPoint)
-        ast.destination = TextFileDestination(nodePositionInGeneratedCode)
+        ast.destination = TextFileDestination(position = nodePositionInGeneratedCode)
     }
 
     fun <T : Node> printList(elements: List<T>, separator: String = ", ") {

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/TrivialFactoryOfParseTreeToASTNodeFactory.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/TrivialFactoryOfParseTreeToASTNodeFactory.kt
@@ -94,7 +94,7 @@ object TrivialFactoryOfParseTreeToASTNodeFactory {
             } catch (e: java.lang.IllegalArgumentException) {
                 throw java.lang.RuntimeException(
                     "Failure while invoking constructor $constructor with args: " +
-                            args.joinToString(",") { "$it (${it?.javaClass})" },
+                        args.joinToString(",") { "$it (${it?.javaClass})" },
                     e
                 )
             }

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/ASTCodeGeneratorTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/ASTCodeGeneratorTest.kt
@@ -55,7 +55,7 @@ class ASTCodeGeneratorTest {
                     else -> null
                 }
             }
-        } .printToString(ex)
+        }.printToString(ex)
         assertEquals("""this.myMethod(YYY, XXX, YYY)""", codeWithNodePrinterOverrider)
     }
 }

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/ASTCodeGeneratorTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/ASTCodeGeneratorTest.kt
@@ -1,5 +1,6 @@
 package com.strumenta.kolasu.codegen
 
+import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.ReferenceByName
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -35,5 +36,26 @@ class ASTCodeGeneratorTest {
         """.trimMargin(),
             code
         )
+    }
+
+    @Test
+    fun printUsingNodePrinterOverrider() {
+        val ex = KMethodCallExpression(
+            KThisExpression(), ReferenceByName("myMethod"),
+            mutableListOf(KStringLiteral("abc"), KIntLiteral(123), KStringLiteral("qer"))
+        )
+        val code = KotlinPrinter().printToString(ex)
+        assertEquals("""this.myMethod("abc", 123, "qer")""", code)
+
+        val codeWithNodePrinterOverrider = KotlinPrinter().also {
+            it.nodePrinterOverrider = { n: Node ->
+                when (n) {
+                    is KStringLiteral -> NodePrinter { output, ast -> output.print("YYY") }
+                    is KIntLiteral -> NodePrinter { output, ast -> output.print("XXX") }
+                    else -> null
+                }
+            }
+        } .printToString(ex)
+        assertEquals("""this.myMethod(YYY, XXX, YYY)""", codeWithNodePrinterOverrider)
     }
 }

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
@@ -186,7 +186,7 @@ class KotlinPrinter : ASTCodeGenerator<KCompilationUnit>() {
     }
 
     fun printToString(expression: KExpression): String {
-        val o = PrinterOutput(nodePrinters)
+        val o = PrinterOutput(nodePrinters, nodePrinterOverrider)
         o.print(expression)
         return o.text()
     }


### PR DESCRIPTION
Add a mechanism to override the behavior of an existing ASTCodeGenerator.
This is used for example to print special strings for node representing placeholders