### PR TITLE
Quoted element refinements

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
@@ -12,6 +12,21 @@ interface Expression
 @NodeType
 interface EntityDeclaration
 
+/**
+ * QuotedElements can be used to represent elements in code matchers templates and code templates. They represent
+ * variable elements in ASTs.
+ *
+ * Code matchers recognize portions of ASTs, while code templates generates portions of ATS.
+ * For example, in a code matcher we could use a QuotedElement to indicate that a certain part of an AST could vary
+ * and that we want to recognize that value. We could have an AST of this type:
+ * SumExpr(QuotedElement("left"), IntLiteral(1)). A code matcher could recognize all of these expressions as matching:
+ * SumExpr(IntLiteral(2), IntLiteral(1)), SumExpr(ReferenceExpression("foo"), IntLiteral(1)), or
+ * SumExpr(MultiplicationExpr(IntLiteral(2), IntLiteral(3)), IntLiteral(1)).
+ * What would vary among these cases would be the value recognized for the QuotedElement.
+ *
+ * Conversely, in a code template the QuotedElement indicates where to insert parameters provided to populate the
+ * template.
+ */
 @NodeType
 interface QuotedElement {
     var placeholderName: String?

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
@@ -11,3 +11,21 @@ interface Expression
  */
 @NodeType
 interface EntityDeclaration
+
+@NodeType
+interface QuotedElement {
+    var placeholderName: String?
+    @property:Internal
+    val multipleQuotedElement: Boolean
+
+    /**
+     * Return true if the node can be represented by this QuotedElement.
+     * For example, a certain QuotedElement could be used only to match expressions or statements.
+     * In case this is a multiple quoted element, and it is used to match many elements, each element
+     * should be passed to this method. For example, if a certain Quoted Element is used to match a sequence of three
+     * statements S1, S2, and S3, all of them should be passed, one by one, as parameters of this method.
+     */
+    fun applicableTo(node: Node) : Boolean = true
+}
+
+

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
@@ -40,7 +40,5 @@ interface PlaceholderElement {
      * should be passed to this method. For example, if a certain PlaceholderElement is used to match a sequence of three
      * statements S1, S2, and S3, all of them should be passed, one by one, as parameters of this method.
      */
-    fun applicableTo(node: Node) : Boolean = true
+    fun applicableTo(node: Node): Boolean = true
 }
-
-

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
@@ -13,31 +13,31 @@ interface Expression
 interface EntityDeclaration
 
 /**
- * QuotedElements can be used to represent elements in code matchers templates and code templates. They represent
+ * PlaceholderElements can be used to represent elements in code matchers templates and code templates. They represent
  * variable elements in ASTs.
  *
  * Code matchers recognize portions of ASTs, while code templates generates portions of ATS.
- * For example, in a code matcher we could use a QuotedElement to indicate that a certain part of an AST could vary
+ * For example, in a code matcher we could use a PlaceholderElement to indicate that a certain part of an AST could vary
  * and that we want to recognize that value. We could have an AST of this type:
- * SumExpr(QuotedElement("left"), IntLiteral(1)). A code matcher could recognize all of these expressions as matching:
+ * SumExpr(PlaceholderElement("left"), IntLiteral(1)). A code matcher could recognize all of these expressions as matching:
  * SumExpr(IntLiteral(2), IntLiteral(1)), SumExpr(ReferenceExpression("foo"), IntLiteral(1)), or
  * SumExpr(MultiplicationExpr(IntLiteral(2), IntLiteral(3)), IntLiteral(1)).
- * What would vary among these cases would be the value recognized for the QuotedElement.
+ * What would vary among these cases would be the value recognized for the PlaceholderElement.
  *
- * Conversely, in a code template the QuotedElement indicates where to insert parameters provided to populate the
+ * Conversely, in a code template the PlaceholderElement indicates where to insert parameters provided to populate the
  * template.
  */
 @NodeType
-interface QuotedElement {
+interface PlaceholderElement {
     var placeholderName: String?
     @property:Internal
-    val multipleQuotedElement: Boolean
+    val multiplePlaceholderElement: Boolean
 
     /**
-     * Return true if the node can be represented by this QuotedElement.
-     * For example, a certain QuotedElement could be used only to match expressions or statements.
+     * Return true if the node can be represented by this PlaceholderElement.
+     * For example, a certain PlaceholderElement could be used only to match expressions or statements.
      * In case this is a multiple quoted element, and it is used to match many elements, each element
-     * should be passed to this method. For example, if a certain Quoted Element is used to match a sequence of three
+     * should be passed to this method. For example, if a certain PlaceholderElement is used to match a sequence of three
      * statements S1, S2, and S3, all of them should be passed, one by one, as parameters of this method.
      */
     fun applicableTo(node: Node) : Boolean = true

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -278,7 +278,7 @@ fun Node.transformChildren(operation: (Node) -> Node) {
                         property.setter.call(this, newValue)
                         newValue.parent = this
                     } else {
-                        throw ImmutablePropertyException(property, value)
+                        throw ImmutablePropertyException(property, this)
                     }
                 }
             }

--- a/core/src/main/kotlin/com/strumenta/kolasu/testing/testing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/testing/testing.kt
@@ -77,6 +77,16 @@ fun <T : Node> assertParsingResultsAreEqual(expected: ParsingResult<T>, actual: 
     }
 }
 
+fun <N:Node>assertASTsAreEqual(
+    expected: Node,
+    actual: ParsingResult<N>,
+    context: String = "<root>",
+    considerPosition: Boolean = false
+) {
+    assertEquals(0, actual.issues.size, actual.issues.toString())
+    assertASTsAreEqual(expected=expected, actual=actual.root!!, context=context, considerPosition=considerPosition)
+}
+
 fun assertASTsAreEqual(
     expected: Node,
     actual: Node,

--- a/core/src/main/kotlin/com/strumenta/kolasu/testing/testing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/testing/testing.kt
@@ -77,14 +77,17 @@ fun <T : Node> assertParsingResultsAreEqual(expected: ParsingResult<T>, actual: 
     }
 }
 
-fun <N:Node>assertASTsAreEqual(
+fun <N : Node> assertASTsAreEqual(
     expected: Node,
     actual: ParsingResult<N>,
     context: String = "<root>",
     considerPosition: Boolean = false
 ) {
     assertEquals(0, actual.issues.size, actual.issues.toString())
-    assertASTsAreEqual(expected=expected, actual=actual.root!!, context=context, considerPosition=considerPosition)
+    assertASTsAreEqual(
+        expected = expected, actual = actual.root!!, context = context,
+        considerPosition = considerPosition
+    )
 }
 
 fun assertASTsAreEqual(

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/kotlinast.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/kotlinast.kt
@@ -69,7 +69,7 @@ data class KReferenceExpr(var symbol: String) : KExpression()
 data class KStringLiteral(var value: String) : KExpression()
 data class KIntLiteral(var value: Int) : KExpression()
 
-data class KQuotedExpr(var name: String? = null) : KExpression()
+data class KPlaceholderExpr(var name: String? = null) : KExpression()
 
 data class KUniIsExpression(var ktype: KType) : KExpression()
 

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/Metamodel.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/Metamodel.kt
@@ -84,6 +84,11 @@ val EntityDeclarationHandler = KolasuClassHandler(
     STARLASU_METAMODEL
         .getEClass("EntityDeclaration")
 )
+val QuotedElementHandler = KolasuClassHandler(
+    QuotedElement::class,
+    STARLASU_METAMODEL
+        .getEClass("QuotedElement")
+)
 
 val StringHandler = KolasuDataTypeHandler(String::class, EcorePackage.eINSTANCE.eString)
 val CharHandler = KolasuDataTypeHandler(Char::class, EcorePackage.eINSTANCE.eChar)

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/Metamodel.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/Metamodel.kt
@@ -84,10 +84,10 @@ val EntityDeclarationHandler = KolasuClassHandler(
     STARLASU_METAMODEL
         .getEClass("EntityDeclaration")
 )
-val QuotedElementHandler = KolasuClassHandler(
-    QuotedElement::class,
+val PlaceholderElementHandler = KolasuClassHandler(
+    PlaceholderElement::class,
     STARLASU_METAMODEL
-        .getEClass("QuotedElement")
+        .getEClass("PlaceholderElement")
 )
 
 val StringHandler = KolasuDataTypeHandler(String::class, EcorePackage.eINSTANCE.eString)

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
@@ -70,6 +70,7 @@ class MetamodelBuilder(packageName: String, nsURI: String, nsPrefix: String, res
         eclassTypeHandlers.add(StatementHandler)
         eclassTypeHandlers.add(ExpressionHandler)
         eclassTypeHandlers.add(EntityDeclarationHandler)
+        eclassTypeHandlers.add(QuotedElementHandler)
     }
 
     /**

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
@@ -70,7 +70,7 @@ class MetamodelBuilder(packageName: String, nsURI: String, nsPrefix: String, res
         eclassTypeHandlers.add(StatementHandler)
         eclassTypeHandlers.add(ExpressionHandler)
         eclassTypeHandlers.add(EntityDeclarationHandler)
-        eclassTypeHandlers.add(QuotedElementHandler)
+        eclassTypeHandlers.add(PlaceholderElementHandler)
     }
 
     /**

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/kolasu_metamodel.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/kolasu_metamodel.kt
@@ -87,6 +87,10 @@ private fun createStarlasuMetamodel(): EPackage {
     ePackage.createEClass("EntityDeclaration").apply {
         this.isInterface = true
     }
+    ePackage.createEClass("QuotedElement").apply {
+        this.isInterface = true
+        addAttribute("placeholderName", stringDT, 0, 1)
+    }
 
     val issueType = EcoreFactory.eINSTANCE.createEEnum()
     issueType.name = "IssueType"

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/kolasu_metamodel.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/kolasu_metamodel.kt
@@ -87,7 +87,7 @@ private fun createStarlasuMetamodel(): EPackage {
     ePackage.createEClass("EntityDeclaration").apply {
         this.isInterface = true
     }
-    ePackage.createEClass("QuotedElement").apply {
+    ePackage.createEClass("PlaceholderElement").apply {
         this.isInterface = true
         addAttribute("placeholderName", stringDT, 0, 1)
     }

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
@@ -452,6 +452,18 @@ class EMFCLIToolTest {
     "name" : "EntityDeclaration",
     "interface" : true
   }, {
+    "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+    "name" : "QuotedElement",
+    "interface" : true,
+    "eStructuralFeatures" : [ {
+      "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+      "name" : "placeholderName",
+      "eType" : {
+        "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
+        "${'$'}ref" : "http://www.eclipse.org/emf/2002/Ecore#//EString"
+      }
+    } ]
+  }, {
     "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EEnum",
     "name" : "IssueType",
     "eLiterals" : [ {

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
@@ -453,7 +453,7 @@ class EMFCLIToolTest {
     "interface" : true
   }, {
     "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EClass",
-    "name" : "QuotedElement",
+    "name" : "PlaceholderElement",
     "interface" : true,
     "eStructuralFeatures" : [ {
       "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",


### PR DESCRIPTION
Introducing QuotedElements. QuotedElement is used to represent elements in code templates and code matcher.
For example, in a code matcher: \`expr:v\` + 1, where \`expr:v\` is a QuotedElement, should match any code containing any expression added to 1.

In a code template \`expr:v\` + 1 indicates that, given expression `v` we want to sum it to 1.