### PR TITLE
Fix method not found when of type list

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/TrivialFactoryOfParseTreeToASTNodeFactory.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/TrivialFactoryOfParseTreeToASTNodeFactory.kt
@@ -72,7 +72,10 @@ object TrivialFactoryOfParseTreeToASTNodeFactory {
                 val searchedName = nameConversions.find { it.second == parameterName }?.first ?: parameterName
                 val parseTreeMember = parseTreeNode.javaClass.kotlin.memberProperties.find { it.name == searchedName }
                 if (parseTreeMember == null) {
-                    val method = parseTreeNode.javaClass.kotlin.memberFunctions.find { it.name == searchedName }
+                    val method =
+                        parseTreeNode.javaClass.kotlin.memberFunctions.find {
+                            it.name == searchedName && it.parameters.size == 1
+                        }
                     if (method == null) {
                         TODO(
                             "Unable to convert $parameterName (looking for $searchedName in " +


### PR DESCRIPTION
ANTLR is generating two members for children of list types, one returning the whole list, the other just one child when provided an index.
We always need the full list with a single parameter, otherwise we get `Exception java.lang.IllegalArgumentException: Callable expects 2 arguments, but 1 were provided` when using `registerTrivialPTtoASTConversion`.