### PR TITLE
AssertASTsAreEqual now does not crash when collections are null

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/testing/testing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/testing/testing.kt
@@ -108,16 +108,22 @@ fun assertASTsAreEqual(
                     if (expectedPropValue is IgnoreChildren<*>) {
                         // Nothing to do
                     } else {
-                        val actualPropValueCollection = actualPropValue as Collection<Node>
-                        val expectedPropValueCollection = expectedPropValue as Collection<Node>
+                        val actualPropValueCollection = actualPropValue?.let { it as Collection<Node> }
+                        val expectedPropValueCollection = expectedPropValue?.let { it as Collection<Node> }
                         assertEquals(
-                            expectedPropValueCollection.size, actualPropValueCollection.size,
-                            "$context.${expectedProperty.name} length"
+                            actualPropValueCollection == null, expectedPropValueCollection == null,
+                            "$context.${expectedProperty.name} nullness"
                         )
-                        val expectedIt = expectedPropValueCollection.iterator()
-                        val actualIt = actualPropValueCollection.iterator()
-                        for (i in expectedPropValueCollection.indices) {
-                            assertASTsAreEqual(expectedIt.next(), actualIt.next(), "$context[$i]")
+                        if (actualPropValueCollection != null && expectedPropValueCollection != null) {
+                            assertEquals(
+                                expectedPropValueCollection?.size, actualPropValueCollection?.size,
+                                "$context.${expectedProperty.name} length"
+                            )
+                            val expectedIt = expectedPropValueCollection.iterator()
+                            val actualIt = actualPropValueCollection.iterator()
+                            for (i in expectedPropValueCollection.indices) {
+                                assertASTsAreEqual(expectedIt.next(), actualIt.next(), "$context[$i]")
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
Fix #167 