### PR TITLE
Make KolasuLexer parametric w.r.t. the type of token produced

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/language/LanguageModule.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/language/LanguageModule.kt
@@ -7,4 +7,4 @@ import com.strumenta.kolasu.parsing.KolasuParser
 /**
  * This permits to parse code into AST and viceversa going from an AST into code.
  */
-class LanguageModule<R : Node>(val parser: KolasuParser<R, *, *>, val codeGenerator: ASTCodeGenerator<R>)
+class LanguageModule<R : Node>(val parser: KolasuParser<R, *, *, *>, val codeGenerator: ASTCodeGenerator<R>)

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -228,7 +228,7 @@ fun Node.indexInContainingProperty(): Int? {
     return if (p == null) {
         null
     } else if (p.value is Collection<*>) {
-        (p.value as Collection<*>).indexOf(this)
+        p.value.indexOf(this)
     } else {
         0
     }

--- a/core/src/test/kotlin/com/strumenta/kolasu/parsing/KolasuParserTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/parsing/KolasuParserTest.kt
@@ -7,17 +7,33 @@ import com.strumenta.simplelang.SimpleLangParser
 import org.antlr.v4.runtime.CharStream
 import org.antlr.v4.runtime.Lexer
 import org.antlr.v4.runtime.TokenStream
+import org.antlr.v4.runtime.tree.TerminalNode
 import org.junit.Test
+import java.io.InputStream
+import java.nio.charset.Charset
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
-class SimpleLangKolasuParser : KolasuParser<Node, SimpleLangParser, SimpleLangParser.CompilationUnitContext>() {
+class SimpleLangKolasuParser : KolasuParser<Node, SimpleLangParser, SimpleLangParser.CompilationUnitContext,
+    KolasuANTLRToken>() {
     override fun createANTLRLexer(charStream: CharStream): Lexer {
         return SimpleLangLexer(charStream)
     }
 
+    override fun lex(
+        inputStream: InputStream,
+        charset: Charset,
+        onlyFromDefaultChannel: Boolean
+    ): LexingResult<KolasuANTLRToken> {
+        TODO("Not yet implemented")
+    }
+
     override fun createANTLRParser(tokenStream: TokenStream): SimpleLangParser {
         return SimpleLangParser(tokenStream)
+    }
+
+    override fun convertToken(terminalNode: TerminalNode): KolasuANTLRToken {
+        return KolasuANTLRToken(TokenCategory.PLAIN_TEXT, terminalNode.symbol)
     }
 
     override fun parseTreeToAst(

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/EMFMetamodelSupport.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/EMFMetamodelSupport.kt
@@ -2,6 +2,7 @@ package com.strumenta.kolasu.emf
 
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.parsing.KolasuParser
+import com.strumenta.kolasu.parsing.KolasuToken
 import com.strumenta.kolasu.parsing.ParsingResult
 import com.strumenta.kolasu.validation.Result
 import org.antlr.v4.runtime.Parser
@@ -68,8 +69,8 @@ fun ParsingResult<*>.saveModel(
  * In particular, this parser can generate the metamodel. We can then use [Node.toEObject] to translate a tree into
  * its EMF representation.
  */
-abstract class EcoreEnabledParser<R : Node, P : Parser, C : ParserRuleContext> :
-    KolasuParser<R, P, C>(), EMFMetamodelSupport {
+abstract class EcoreEnabledParser<R : Node, P : Parser, C : ParserRuleContext, T : KolasuToken> :
+    KolasuParser<R, P, C, T>(), EMFMetamodelSupport {
 
     /**
      * Generates the metamodel. The standard Kolasu metamodel [EPackage][org.eclipse.emf.ecore.EPackage] is included.

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/cli/EMFCLICommands.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/cli/EMFCLICommands.kt
@@ -21,7 +21,7 @@ class EMFModelCommand<R : Node, P>(parserInstantiator: ParserInstantiator<P>) :
         parserInstantiator,
         help = "Parses a file and exports the AST to an EMF (XMI) file.",
         name = "model"
-    ) where P : EcoreEnabledParser<R, *, *> {
+    ) where P : EcoreEnabledParser<R, *, *, *> {
     val metamodel by option("--metamodel")
     val outputDirectory by option("--output", "-o")
         .file()

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/cli/EMFCLITool.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/cli/EMFCLITool.kt
@@ -13,7 +13,7 @@ class EMFCLITool<R : Node, P>(
     parserInstantiator: ParserInstantiator<P>,
     metamodelSupport: EMFMetamodelSupport,
     replacedConsole: CliktConsole? = null
-) : CliktCommand(invokeWithoutSubcommand = false) where P : EcoreEnabledParser<R, *, *> {
+) : CliktCommand(invokeWithoutSubcommand = false) where P : EcoreEnabledParser<R, *, *, *> {
     init {
         subcommands(EMFModelCommand(parserInstantiator), EMFMetaModelCommand(metamodelSupport))
         context { replacedConsole?.apply { console = replacedConsole } }

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
@@ -6,6 +6,8 @@ import com.strumenta.kolasu.emf.EcoreEnabledParser
 import com.strumenta.kolasu.emf.MetamodelBuilder
 import com.strumenta.kolasu.model.Named
 import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.parsing.KolasuANTLRToken
+import com.strumenta.kolasu.parsing.LexingResult
 import com.strumenta.kolasu.parsing.ParsingResult
 import com.strumenta.kolasu.validation.Issue
 import org.antlr.v4.runtime.CharStream
@@ -13,9 +15,11 @@ import org.antlr.v4.runtime.Lexer
 import org.antlr.v4.runtime.Parser
 import org.antlr.v4.runtime.ParserRuleContext
 import org.antlr.v4.runtime.TokenStream
+import org.antlr.v4.runtime.tree.TerminalNode
 import org.eclipse.emf.ecore.resource.Resource
 import org.junit.Test
 import java.io.File
+import java.io.InputStream
 import java.nio.charset.Charset
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.pathString
@@ -26,7 +30,7 @@ data class MyCompilationUnit(val decls: List<MyEntityDecl>) : Node()
 data class MyEntityDecl(override var name: String, val fields: List<MyFieldDecl>) : Node(), Named
 data class MyFieldDecl(override var name: String) : Node(), Named
 
-class MyDummyParser : EcoreEnabledParser<MyCompilationUnit, Parser, ParserRuleContext>() {
+class MyDummyParser : EcoreEnabledParser<MyCompilationUnit, Parser, ParserRuleContext, KolasuANTLRToken>() {
     override fun doGenerateMetamodel(resource: Resource) {
         val mmbuilder = MetamodelBuilder("com.strumenta.kolasu.emf.cli", "https://dummy.com/mm", "dm")
         mmbuilder.provideClass(MyCompilationUnit::class)
@@ -39,6 +43,10 @@ class MyDummyParser : EcoreEnabledParser<MyCompilationUnit, Parser, ParserRuleCo
     }
 
     override fun createANTLRParser(tokenStream: TokenStream): Parser {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToken(terminalNode: TerminalNode): KolasuANTLRToken {
         TODO("Not yet implemented")
     }
 
@@ -62,6 +70,14 @@ class MyDummyParser : EcoreEnabledParser<MyCompilationUnit, Parser, ParserRuleCo
 
     override fun parse(file: File, charset: Charset, considerPosition: Boolean): ParsingResult<MyCompilationUnit> {
         return expectedResults[file] ?: throw java.lang.IllegalArgumentException("Unexpected file $file")
+    }
+
+    override fun lex(
+        inputStream: InputStream,
+        charset: Charset,
+        onlyFromDefaultChannel: Boolean
+    ): LexingResult<KolasuANTLRToken> {
+        TODO("Not yet implemented")
     }
 }
 

--- a/playground/src/main/kotlin/com/strumenta/kolasu/playground/PlaygroundExampleGenerator.kt
+++ b/playground/src/main/kotlin/com/strumenta/kolasu/playground/PlaygroundExampleGenerator.kt
@@ -17,7 +17,7 @@ import java.io.FileWriter
 import java.io.Writer
 
 class PlaygroundExampleGenerator(
-    val parser: EcoreEnabledParser<*, *, *>,
+    val parser: EcoreEnabledParser<*, *, *, *>,
     val directory: File,
     val failOnError: Boolean = true,
     resourceURI: URI = URI.createURI("")


### PR DESCRIPTION
These changes are required to make the RPG Lexer works, as it uses the RPGToken and not KolasuANTLRToken.
In my opinion this seems complicated, and we may consider adding the text field into KolasuToken, making it a concrete class. We could then make a method that given an ANTLR token convert it to a KolasuToken.