### PR TITLE
Add support for RMI

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
@@ -1,12 +1,13 @@
 package com.strumenta.kolasu.model
 
+import java.io.Serializable
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.memberProperties
 
-interface Origin {
+interface Origin : Serializable {
     val position: Position?
     val sourceText: String?
     val source: Source?
@@ -21,7 +22,7 @@ data class CompositeOrigin(
     override val sourceText: String?
 ) : Origin
 
-interface Destination
+interface Destination : Serializable
 
 data class CompositeDestination(val elements: List<Destination>) : Destination
 data class TextFileDestination(val position: Position?) : Destination
@@ -32,7 +33,7 @@ data class TextFileDestination(val position: Position?) : Destination
  * It implements Origin as it could be the source of a AST-to-AST transformation, so the node itself can be
  * the Origin of another node.
  */
-open class Node() : Origin, Destination {
+open class Node() : Origin, Destination, Serializable {
 
     @Internal
     protected var positionOverride: Position? = null

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
@@ -7,25 +7,25 @@ import kotlin.reflect.KVisibility
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.memberProperties
 
-interface Origin : Serializable {
+interface Origin {
     val position: Position?
     val sourceText: String?
     val source: Source?
         get() = position?.source
 }
 
-class SimpleOrigin(override val position: Position?, override val sourceText: String?) : Origin
+class SimpleOrigin(override val position: Position?, override val sourceText: String?) : Origin, Serializable
 
 data class CompositeOrigin(
     val elements: List<Origin>,
     override val position: Position?,
     override val sourceText: String?
-) : Origin
+) : Origin, Serializable
 
-interface Destination : Serializable
+interface Destination
 
-data class CompositeDestination(val elements: List<Destination>) : Destination
-data class TextFileDestination(val position: Position?) : Destination
+data class CompositeDestination(val elements: List<Destination>) : Destination, Serializable
+data class TextFileDestination(val position: Position?) : Destination, Serializable
 
 /**
  * The Abstract Syntax Tree will be constituted by instances of Node.

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Naming.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Naming.kt
@@ -1,5 +1,7 @@
 package com.strumenta.kolasu.model
 
+import java.io.Serializable
+
 /**
  * An entity that can have a name
  */
@@ -27,7 +29,7 @@ interface Named : PossiblyNamed {
  * This is not statically enforced as we may want to use some interface, which cannot extend Node.
  * However, this is enforced dynamically.
  */
-class ReferenceByName<N>(val name: String, initialReferred: N? = null) where N : PossiblyNamed {
+class ReferenceByName<N>(val name: String, initialReferred: N? = null) : Serializable where N : PossiblyNamed {
 
     var referred: N? = null
         set(value) {

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Position.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Position.kt
@@ -1,6 +1,7 @@
 package com.strumenta.kolasu.model
 
 import java.io.File
+import java.io.Serializable
 import java.net.URL
 import java.nio.file.Path
 
@@ -16,7 +17,7 @@ val START_POINT = Point(START_LINE, START_COLUMN)
  * - the point before the first character will be Point(1, 0)
  * - the point at the end of the first line, after the letter "O" will be Point(1, 5)
  */
-data class Point(val line: Int, val column: Int) : Comparable<Point> {
+data class Point(val line: Int, val column: Int) : Comparable<Point>, Serializable {
     override fun compareTo(other: Point): Int {
         if (line == other.line) {
             return this.column - other.column
@@ -114,7 +115,7 @@ fun linePosition(lineNumber: Int, lineCode: String, source: Source? = null): Pos
     return Position(Point(lineNumber, START_COLUMN), Point(lineNumber, lineCode.length), source)
 }
 
-abstract class Source
+abstract class Source : Serializable
 class SourceSet(val name: String, val root: Path)
 class SourceSetElement(val sourceSet: SourceSet, val relativePath: Path) : Source()
 class FileSource(val file: File) : Source()
@@ -140,7 +141,7 @@ data class SyntheticSource(val description: String) : Source()
  * Consider a file with one line, containing text "HELLO".
  * The Position of such text will be Position(Point(1, 0), Point(1, 5)).
  */
-data class Position(val start: Point, val end: Point, var source: Source? = null) : Comparable<Position> {
+data class Position(val start: Point, val end: Point, var source: Source? = null) : Comparable<Position>, Serializable {
 
     override fun toString(): String {
         return "Position(start=$start, end=$end${if (source == null) "" else ", source=$source"})"

--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/ANTLRParseTreeUtils.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/ANTLRParseTreeUtils.kt
@@ -61,6 +61,8 @@ fun Node.getText(code: String): String? = position?.text(code)
 /**
  * An Origin corresponding to a ParseTreeNode. This is used to indicate that an AST Node has been obtained
  * by mapping an original ParseTreeNode.
+ *
+ * Note that this is NOT serializable as ParseTree elements are not Serializable.
  */
 class ParseTreeOrigin(val parseTree: ParseTree, override var source: Source? = null) : Origin {
     override val position: Position?

--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
@@ -56,7 +56,7 @@ data class TokenCategory(val type: String) {
 /**
  * A token is a portion of text that has been assigned a category.
  */
-open class KolasuToken(open val category: TokenCategory, open val position: Position, open val text: String)
+open class KolasuToken(open val category: TokenCategory, open val position: Position, open val text: String) : Serializable
 
 /**
  * A [KolasuToken] generated from a [Token]. The [token] contains additional information that is specific to ANTLR,
@@ -151,7 +151,7 @@ class ParsingResult<RootNode : Node>(
 
 fun String.toStream(charset: Charset = Charsets.UTF_8) = ByteArrayInputStream(toByteArray(charset))
 
-interface KolasuLexer<T : KolasuToken> {
+interface KolasuLexer<T : KolasuToken> : Serializable {
 
     /**
      * Performs "lexing" on the given code string, i.e., it breaks it into tokens.

--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
@@ -13,13 +13,14 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
+import java.io.Serializable
 import java.nio.charset.Charset
 
 open class CodeProcessingResult<D>(
     val issues: List<Issue>,
     val data: D?,
     val code: String? = null
-) {
+) : Serializable {
     val correct: Boolean
         get() = issues.none { it.severity != IssueSeverity.INFO }
 

--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
@@ -56,7 +56,11 @@ data class TokenCategory(val type: String) {
 /**
  * A token is a portion of text that has been assigned a category.
  */
-open class KolasuToken(open val category: TokenCategory, open val position: Position, open val text: String) : Serializable
+open class KolasuToken(
+    open val category: TokenCategory,
+    open val position: Position,
+    open val text: String
+) : Serializable
 
 /**
  * A [KolasuToken] generated from a [Token]. The [token] contains additional information that is specific to ANTLR,

--- a/core/src/main/kotlin/com/strumenta/kolasu/symbolresolution/LocalSymbolResolver.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/symbolresolution/LocalSymbolResolver.kt
@@ -2,12 +2,13 @@ package com.strumenta.kolasu.symbolresolution
 
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.validation.Issue
+import java.io.Serializable
 
 /**
  * This object performs symbol resolution within a single AST.
  * It is not to be used to perform cross-ASTs symbol resolution.
  */
-abstract class LocalSymbolResolver {
+abstract class LocalSymbolResolver : Serializable {
     /**
      * This will resolve symbols on the given AST. It will set the links in the ReferenceByName found.
      * It will return a list of issues encountered during symbol resolution.


### PR DESCRIPTION
By making elements Serializable we can expose the parsers through RMI, as we do in the Audit Viewer