### PR TITLE
TrivialFactoryOfParseTreeToASTNodeFactory refactoring

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/mapping/ParseTreeToASTTransformer.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/mapping/ParseTreeToASTTransformer.kt
@@ -43,7 +43,10 @@ open class ParseTreeToASTTransformer(issues: MutableList<Issue> = mutableListOf(
         kclass: KClass<P>
     ): NodeFactory<P, Node> = registerNodeFactory(kclass) { source, transformer, _ ->
         val nodeChildren = source.children.filterIsInstance<ParserRuleContext>()
-        require(nodeChildren.size == 1) { "Node $source (${source.javaClass}) has ${nodeChildren.size} nide children: $nodeChildren" }
+        require(nodeChildren.size == 1) {
+            "Node $source (${source.javaClass}) has ${nodeChildren.size} " +
+                "node children: $nodeChildren"
+        }
         transformer.transform(nodeChildren[0]) as Node
     }
 }

--- a/core/src/main/kotlin/com/strumenta/kolasu/mapping/ParseTreeToASTTransformer.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/mapping/ParseTreeToASTTransformer.kt
@@ -5,9 +5,11 @@ import com.strumenta.kolasu.model.Origin
 import com.strumenta.kolasu.parsing.ParseTreeOrigin
 import com.strumenta.kolasu.parsing.withParseTreeNode
 import com.strumenta.kolasu.transformation.ASTTransformer
+import com.strumenta.kolasu.transformation.NodeFactory
 import com.strumenta.kolasu.validation.Issue
 import org.antlr.v4.runtime.ParserRuleContext
 import org.antlr.v4.runtime.tree.ParseTree
+import kotlin.reflect.KClass
 
 /**
  * Implements a transformation from an ANTLR parse tree (the output of the parser) to an AST (a higher-level
@@ -35,5 +37,13 @@ open class ParseTreeToASTTransformer(issues: MutableList<Issue> = mutableListOf(
 
     override fun asOrigin(source: Any): Origin? {
         return if (source is ParseTree) ParseTreeOrigin(source) else null
+    }
+
+    inline fun <P : ParserRuleContext> registerNodeFactoryUnwrappingChild(
+        kclass: KClass<P>
+    ): NodeFactory<P, Node> = registerNodeFactory(kclass) { source, transformer, _ ->
+        val nodeChildren = source.children.filterIsInstance<ParserRuleContext>()
+        require(nodeChildren.size == 1) { "Node $source (${source.javaClass}) has ${nodeChildren.size} nide children: $nodeChildren" }
+        transformer.transform(nodeChildren[0]) as Node
     }
 }

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/TrivialFactoryOfParseTreeToASTNodeFactory.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/TrivialFactoryOfParseTreeToASTNodeFactory.kt
@@ -45,11 +45,8 @@ object TrivialFactoryOfParseTreeToASTNodeFactory {
             }
             is ParserRuleContext -> {
                 return when (expectedType) {
-                    String::class.createType() -> {
+                    String::class.createType(), String::class.createType(nullable = true) -> {
                         value.text
-                    }
-                    String::class.createType(nullable = true) -> {
-                        value?.text
                     }
                     else -> {
                         astTransformer.transform(value)

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/TrivialFactoryOfParseTreeToASTNodeFactory.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/TrivialFactoryOfParseTreeToASTNodeFactory.kt
@@ -44,10 +44,17 @@ object TrivialFactoryOfParseTreeToASTNodeFactory {
                 return value.map { convert(it, astTransformer, expectedType.arguments[0].type!!) }
             }
             is ParserRuleContext -> {
-                if (expectedType == String::class.createType()) {
-                    return value.text
+                return when (expectedType) {
+                    String::class.createType() -> {
+                        value.text
+                    }
+                    String::class.createType(nullable = true) -> {
+                        value?.text
+                    }
+                    else -> {
+                        astTransformer.transform(value)
+                    }
                 }
-                return astTransformer.transform(value)
             }
             null -> {
                 return null

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/TrivialFactoryOfParseTreeToASTNodeFactory.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/TrivialFactoryOfParseTreeToASTNodeFactory.kt
@@ -11,6 +11,7 @@ import org.antlr.v4.runtime.Token
 import org.antlr.v4.runtime.tree.TerminalNode
 import kotlin.reflect.KCallable
 import kotlin.reflect.KType
+import kotlin.reflect.full.createType
 import kotlin.reflect.full.memberFunctions
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
@@ -43,6 +44,9 @@ object TrivialFactoryOfParseTreeToASTNodeFactory {
                 return value.map { convert(it, astTransformer, expectedType.arguments[0].type!!) }
             }
             is ParserRuleContext -> {
+                if (expectedType == String::class.createType()) {
+                    return value.text
+                }
                 return astTransformer.transform(value)
             }
             null -> {

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/TrivialFactoryOfParseTreeToASTNodeFactory.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/TrivialFactoryOfParseTreeToASTNodeFactory.kt
@@ -74,8 +74,8 @@ object TrivialFactoryOfParseTreeToASTNodeFactory {
                     T::class.primaryConstructor!!
                 } else {
                     throw java.lang.RuntimeException(
-                        "Trivial Factory supports only classes with exactly one constructor or a primary constructor. " +
-                                "Class ${T::class.qualifiedName} has ${constructors.size}"
+                        "Trivial Factory supports only classes with exactly one constructor or a " +
+                            "primary constructor. Class ${T::class.qualifiedName} has ${constructors.size}"
                     )
                 }
             } else {


### PR DESCRIPTION
Minor changes to the TrivialFactoryOfParseTreeToASTNodeFactory class, based on the work done in the Java language module.

Essentially:
* When we are waiting for a String or a String? we just get the text of the corresponding element, which could be not just a token but also a node such as IdentifierContext in the case of the Java language module
* When there is more than one constructor we pick the primary one, if available