### PR TITLE
ParseTreeToASTTransformer: option to set the source of each position/range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,5 @@ src/test/gen
 generated-test-src
 /*.ecore
 /*.json
-/*.xmi**/bin
+/*.xmi
 **/bin/

--- a/core/src/main/kotlin/com/strumenta/kolasu/mapping/ParseTreeToASTTransformer.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/mapping/ParseTreeToASTTransformer.kt
@@ -19,7 +19,8 @@ import kotlin.reflect.KClass
 open class ParseTreeToASTTransformer(
     issues: MutableList<Issue> = mutableListOf(),
     allowGenericNode: Boolean = true,
-    val source: Source? = null) : ASTTransformer(issues, allowGenericNode) {
+    val source: Source? = null
+) : ASTTransformer(issues, allowGenericNode) {
     /**
      * Performs the transformation of a node and, recursively, its descendants. In addition to the overridden method,
      * it also assigns the parseTreeNode to the AST node so that it can keep track of its position.

--- a/core/src/main/kotlin/com/strumenta/kolasu/mapping/ParseTreeToASTTransformer.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/mapping/ParseTreeToASTTransformer.kt
@@ -2,6 +2,7 @@ package com.strumenta.kolasu.mapping
 
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Origin
+import com.strumenta.kolasu.model.Source
 import com.strumenta.kolasu.parsing.ParseTreeOrigin
 import com.strumenta.kolasu.parsing.withParseTreeNode
 import com.strumenta.kolasu.transformation.ASTTransformer
@@ -15,8 +16,10 @@ import kotlin.reflect.KClass
  * Implements a transformation from an ANTLR parse tree (the output of the parser) to an AST (a higher-level
  * representation of the source code).
  */
-open class ParseTreeToASTTransformer(issues: MutableList<Issue> = mutableListOf(), allowGenericNode: Boolean = true) :
-    ASTTransformer(issues, allowGenericNode) {
+open class ParseTreeToASTTransformer(
+    issues: MutableList<Issue> = mutableListOf(),
+    allowGenericNode: Boolean = true,
+    val source: Source? = null) : ASTTransformer(issues, allowGenericNode) {
     /**
      * Performs the transformation of a node and, recursively, its descendants. In addition to the overridden method,
      * it also assigns the parseTreeNode to the AST node so that it can keep track of its position.
@@ -24,8 +27,12 @@ open class ParseTreeToASTTransformer(issues: MutableList<Issue> = mutableListOf(
      */
     override fun transform(source: Any?, parent: Node?): Node? {
         val node = super.transform(source, parent)
-        if (node != null && node.origin == null && source is ParserRuleContext) {
-            node.withParseTreeNode(source)
+        if (node != null && source is ParserRuleContext) {
+            if (node.origin == null) {
+                node.withParseTreeNode(source, this.source)
+            } else if (node.position != null && node.source == null) {
+                node.position!!.source = this.source
+            }
         }
         return node
     }

--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/ASTParser.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/ASTParser.kt
@@ -31,8 +31,12 @@ interface ASTParser<R : Node> {
     ): ParsingResult<R> =
         parse(inputStreamToString(inputStream, charset), considerPosition, measureLexingTime, source)
 
-    fun parse(code: String, considerPosition: Boolean = true, measureLexingTime: Boolean = false,
-              source: Source? = null): ParsingResult<R>
+    fun parse(
+        code: String,
+        considerPosition: Boolean = true,
+        measureLexingTime: Boolean = false,
+        source: Source? = null
+    ): ParsingResult<R>
 
     fun parse(code: String, considerPosition: Boolean = true, measureLexingTime: Boolean = false): ParsingResult<R> =
         parse(code, considerPosition, measureLexingTime, StringSource(code))
@@ -41,5 +45,6 @@ interface ASTParser<R : Node> {
         file: File,
         charset: Charset = Charsets.UTF_8,
         considerPosition: Boolean = true,
-        measureLexingTime: Boolean = false) : ParsingResult<R>
+        measureLexingTime: Boolean = false
+    ): ParsingResult<R>
 }

--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/ASTParser.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/ASTParser.kt
@@ -1,6 +1,8 @@
 package com.strumenta.kolasu.parsing
 
 import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.Source
+import com.strumenta.kolasu.model.StringSource
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStream
@@ -24,10 +26,20 @@ interface ASTParser<R : Node> {
         inputStream: InputStream,
         charset: Charset = Charsets.UTF_8,
         considerPosition: Boolean = true,
-        measureLexingTime: Boolean = false
-    ):
-        ParsingResult<R> = parse(inputStreamToString(inputStream, charset), considerPosition, measureLexingTime)
-    fun parse(code: String, considerPosition: Boolean = true, measureLexingTime: Boolean = false): ParsingResult<R>
+        measureLexingTime: Boolean = false,
+        source: Source? = null
+    ): ParsingResult<R> =
+        parse(inputStreamToString(inputStream, charset), considerPosition, measureLexingTime, source)
 
-    fun parse(file: File, charset: Charset = Charsets.UTF_8, considerPosition: Boolean = true): ParsingResult<R>
+    fun parse(code: String, considerPosition: Boolean = true, measureLexingTime: Boolean = false,
+              source: Source? = null): ParsingResult<R>
+
+    fun parse(code: String, considerPosition: Boolean = true, measureLexingTime: Boolean = false): ParsingResult<R> =
+        parse(code, considerPosition, measureLexingTime, StringSource(code))
+
+    fun parse(
+        file: File,
+        charset: Charset = Charsets.UTF_8,
+        considerPosition: Boolean = true,
+        measureLexingTime: Boolean = false) : ParsingResult<R>
 }

--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/KolasuParser.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/KolasuParser.kt
@@ -132,7 +132,8 @@ abstract class KolasuParser<R : Node, P : Parser, C : ParserRuleContext, T : Kol
     protected abstract fun parseTreeToAst(
         parseTreeRoot: C,
         considerPosition: Boolean = true,
-        issues: MutableList<Issue>
+        issues: MutableList<Issue>,
+        source: Source? = null
     ): R?
 
     protected open fun attachListeners(parser: P, issues: MutableList<Issue>) {
@@ -233,21 +234,20 @@ abstract class KolasuParser<R : Node, P : Parser, C : ParserRuleContext, T : Kol
         return ast
     }
 
-    override fun parse(code: String, considerPosition: Boolean, measureLexingTime: Boolean): ParsingResult<R> {
-        val inputStream = CharStreams.fromString(code)
-        return parse(inputStream, considerPosition, measureLexingTime)
-    }
+    override fun parse(code: String, considerPosition: Boolean, measureLexingTime: Boolean, source: Source?): ParsingResult<R> =
+        parse(CharStreams.fromString(code), considerPosition, measureLexingTime, source)
 
     @JvmOverloads
     fun parse(
         inputStream: CharStream,
         considerPosition: Boolean = true,
-        measureLexingTime: Boolean = false
+        measureLexingTime: Boolean = false,
+        source: Source? = null
     ): ParsingResult<R> {
         val start = System.currentTimeMillis()
         val firstStage = parseFirstStage(inputStream, measureLexingTime)
         val myIssues = firstStage.issues.toMutableList()
-        var ast = parseTreeToAst(firstStage.root!!, considerPosition, myIssues)
+        var ast = parseTreeToAst(firstStage.root!!, considerPosition, myIssues, source)
         assignParents(ast)
         ast = if (ast == null) null else postProcessAst(ast, myIssues)
         if (ast != null && !considerPosition) {
@@ -261,8 +261,12 @@ abstract class KolasuParser<R : Node, P : Parser, C : ParserRuleContext, T : Kol
         )
     }
 
-    override fun parse(file: File, charset: Charset, considerPosition: Boolean): ParsingResult<R> =
-        parse(FileInputStream(file), charset, considerPosition)
+    override fun parse(
+        file: File,
+        charset: Charset,
+        considerPosition: Boolean,
+        measureLexingTime: Boolean) : ParsingResult<R> =
+        parse(FileInputStream(file), charset, considerPosition, measureLexingTime, FileSource(file))
 
     // For convenient use from Java
     fun walk(node: Node) = node.walk()

--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/KolasuParser.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/KolasuParser.kt
@@ -234,8 +234,12 @@ abstract class KolasuParser<R : Node, P : Parser, C : ParserRuleContext, T : Kol
         return ast
     }
 
-    override fun parse(code: String, considerPosition: Boolean, measureLexingTime: Boolean, source: Source?): ParsingResult<R> =
-        parse(CharStreams.fromString(code), considerPosition, measureLexingTime, source)
+    override fun parse(
+        code: String,
+        considerPosition: Boolean,
+        measureLexingTime: Boolean,
+        source: Source?
+    ): ParsingResult<R> = parse(CharStreams.fromString(code), considerPosition, measureLexingTime, source)
 
     @JvmOverloads
     fun parse(
@@ -265,7 +269,8 @@ abstract class KolasuParser<R : Node, P : Parser, C : ParserRuleContext, T : Kol
         file: File,
         charset: Charset,
         considerPosition: Boolean,
-        measureLexingTime: Boolean) : ParsingResult<R> =
+        measureLexingTime: Boolean
+    ): ParsingResult<R> =
         parse(FileInputStream(file), charset, considerPosition, measureLexingTime, FileSource(file))
 
     // For convenient use from Java

--- a/core/src/test/kotlin/com/strumenta/kolasu/cli/CLITest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/cli/CLITest.kt
@@ -4,6 +4,7 @@ import com.github.ajalt.clikt.core.PrintHelpMessage
 import com.github.ajalt.clikt.output.CliktConsole
 import com.strumenta.kolasu.model.Named
 import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.Source
 import com.strumenta.kolasu.parsing.ASTParser
 import com.strumenta.kolasu.parsing.ParsingResult
 import org.junit.Test
@@ -20,19 +21,24 @@ data class MyEntityDecl(override var name: String, val fields: List<MyFieldDecl>
 data class MyFieldDecl(override var name: String) : Node(), Named
 
 class MyDummyParser : ASTParser<MyCompilationUnit> {
+
+    val expectedResults = HashMap<File, ParsingResult<MyCompilationUnit>>()
+
     override fun parse(
         code: String,
         considerPosition: Boolean,
-        measureLexingTime: Boolean
+        measureLexingTime: Boolean,
+        source: Source?
     ): ParsingResult<MyCompilationUnit> {
         TODO("Not yet implemented")
     }
 
-    val expectedResults = HashMap<File, ParsingResult<MyCompilationUnit>>()
-
-    override fun parse(file: File, charset: Charset, considerPosition: Boolean): ParsingResult<MyCompilationUnit> {
-        return expectedResults[file] ?: throw java.lang.IllegalArgumentException("Unexpected file $file")
-    }
+    override fun parse(
+        file: File,
+        charset: Charset,
+        considerPosition: Boolean,
+        measureLexingTime: Boolean) : ParsingResult<MyCompilationUnit> =
+        expectedResults[file] ?: throw java.lang.IllegalArgumentException("Unexpected file $file")
 }
 
 class CapturingCliktConsole : CliktConsole {

--- a/core/src/test/kotlin/com/strumenta/kolasu/cli/CLITest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/cli/CLITest.kt
@@ -37,7 +37,8 @@ class MyDummyParser : ASTParser<MyCompilationUnit> {
         file: File,
         charset: Charset,
         considerPosition: Boolean,
-        measureLexingTime: Boolean) : ParsingResult<MyCompilationUnit> =
+        measureLexingTime: Boolean
+    ): ParsingResult<MyCompilationUnit> =
         expectedResults[file] ?: throw java.lang.IllegalArgumentException("Unexpected file $file")
 }
 

--- a/core/src/test/kotlin/com/strumenta/kolasu/parsing/KolasuParserTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/parsing/KolasuParserTest.kt
@@ -1,6 +1,7 @@
 package com.strumenta.kolasu.parsing
 
 import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.Source
 import com.strumenta.kolasu.validation.Issue
 import com.strumenta.simplelang.SimpleLangLexer
 import com.strumenta.simplelang.SimpleLangParser
@@ -24,7 +25,8 @@ class SimpleLangKolasuParser : KolasuParser<Node, SimpleLangParser, SimpleLangPa
     override fun parseTreeToAst(
         parseTreeRoot: SimpleLangParser.CompilationUnitContext,
         considerPosition: Boolean,
-        issues: MutableList<Issue>
+        issues: MutableList<Issue>,
+        source: Source?
     ): Node? = null
 }
 

--- a/core/src/test/kotlin/com/strumenta/kolasu/transformation/ASTTransformerTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/transformation/ASTTransformerTest.kt
@@ -1,7 +1,6 @@
 package com.strumenta.kolasu.transformation
 
 import com.strumenta.kolasu.model.Node
-import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.model.hasValidParents
 import com.strumenta.kolasu.model.withOrigin
 import com.strumenta.kolasu.testing.assertASTsAreEqual

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
@@ -58,7 +58,8 @@ class MyDummyParser : EcoreEnabledParser<MyCompilationUnit, Parser, ParserRuleCo
         file: File,
         charset: Charset,
         considerPosition: Boolean,
-        measureLexingTime: Boolean): ParsingResult<MyCompilationUnit> =
+        measureLexingTime: Boolean
+    ): ParsingResult<MyCompilationUnit> =
         expectedResults[file] ?: throw java.lang.IllegalArgumentException("Unexpected file $file")
 }
 

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
@@ -6,6 +6,7 @@ import com.strumenta.kolasu.emf.EcoreEnabledParser
 import com.strumenta.kolasu.emf.MetamodelBuilder
 import com.strumenta.kolasu.model.Named
 import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.Source
 import com.strumenta.kolasu.parsing.ANTLRTokenFactory
 import com.strumenta.kolasu.parsing.KolasuANTLRToken
 import com.strumenta.kolasu.parsing.ParsingResult
@@ -45,24 +46,20 @@ class MyDummyParser : EcoreEnabledParser<MyCompilationUnit, Parser, ParserRuleCo
     override fun parseTreeToAst(
         parseTreeRoot: ParserRuleContext,
         considerPosition: Boolean,
-        issues: MutableList<Issue>
+        issues: MutableList<Issue>,
+        source: Source?
     ): MyCompilationUnit? {
-        TODO("Not yet implemented")
-    }
-
-    override fun parse(
-        code: String,
-        considerPosition: Boolean,
-        measureLexingTime: Boolean
-    ): ParsingResult<MyCompilationUnit> {
         TODO("Not yet implemented")
     }
 
     val expectedResults = HashMap<File, ParsingResult<MyCompilationUnit>>()
 
-    override fun parse(file: File, charset: Charset, considerPosition: Boolean): ParsingResult<MyCompilationUnit> {
-        return expectedResults[file] ?: throw java.lang.IllegalArgumentException("Unexpected file $file")
-    }
+    override fun parse(
+        file: File,
+        charset: Charset,
+        considerPosition: Boolean,
+        measureLexingTime: Boolean): ParsingResult<MyCompilationUnit> =
+        expectedResults[file] ?: throw java.lang.IllegalArgumentException("Unexpected file $file")
 }
 
 class CapturingCliktConsole : CliktConsole {


### PR DESCRIPTION
This implements issue #197 and modifies KolasuParser to correctly set the source according to the input.
However, this introduces an API change and parsers extending KolasuParser would need to be slightly modified.