### PR TITLE
Aligh withParseTreeOrigin and ParseTreeOrigin

### DIFF
--- a/antlr/src/main/kotlin/com/strumenta/kolasu/antlr/parsing/ANTLRParseTreeUtils.kt
+++ b/antlr/src/main/kotlin/com/strumenta/kolasu/antlr/parsing/ANTLRParseTreeUtils.kt
@@ -94,7 +94,7 @@ class ParseTreeOrigin(val parseTree: ParseTree, override var source: Source? = n
  * Set the origin of the AST node as a ParseTreeOrigin, providing the parseTree is not null.
  * If the parseTree is null, no operation is performed.
  */
-fun <T : Node> T.withParseTreeNode(parseTree: ParserRuleContext?, source: Source? = null): T {
+fun <T : Node> T.withParseTreeNode(parseTree: ParseTree?, source: Source? = null): T {
     if (parseTree != null) {
         this.origin = ParseTreeOrigin(parseTree, source)
     }


### PR DESCRIPTION
The solution found is to relax the constraint on withParseTreeOrigin, so that both accepts a ParseTree instance. The rationale is that a token could be the origin of an AST node, potentially

Fix #154

Asking review from Alessio as he opened the original issue