### PR TITLE
Reorganizing range, source, origin, and destinations

### DIFF
--- a/antlr/src/main/kotlin/com/strumenta/kolasu/antlr/Utils.kt
+++ b/antlr/src/main/kotlin/com/strumenta/kolasu/antlr/Utils.kt
@@ -1,8 +1,9 @@
 package com.strumenta.kolasu.antlr
 
 import com.strumenta.kolasu.model.Node
-import com.strumenta.kolasu.model.NodeDestination
 import com.strumenta.kolasu.model.SimpleOrigin
+import com.strumenta.kolasu.model.contains
+import com.strumenta.kolasu.model.minusAssign
 
 fun Node.detachFromParseTree(keepRange: Boolean = true, keepSourceText: Boolean = false) {
     val existingOrigin = origin
@@ -15,8 +16,8 @@ fun Node.detachFromParseTree(keepRange: Boolean = true, keepSourceText: Boolean 
         } else {
             this.origin = null
         }
-        if (existingOrigin is Node && existingOrigin.destinations.contains(NodeDestination(this))) {
-            existingOrigin.destinations.remove(NodeDestination(this))
+        if ((existingOrigin is Node) && (this in existingOrigin.destinations)) {
+            existingOrigin.destinations -= this
         }
     }
 }

--- a/antlr/src/main/kotlin/com/strumenta/kolasu/antlr/Utils.kt
+++ b/antlr/src/main/kotlin/com/strumenta/kolasu/antlr/Utils.kt
@@ -1,13 +1,15 @@
 package com.strumenta.kolasu.antlr
 
+import com.strumenta.kolasu.antlr.parsing.ParseTreeOrigin
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.SimpleOrigin
-import com.strumenta.kolasu.model.contains
-import com.strumenta.kolasu.model.minusAssign
 
+/**
+ * Remove links to the ParseTree, in order to save memory.
+ */
 fun Node.detachFromParseTree(keepRange: Boolean = true, keepSourceText: Boolean = false) {
     val existingOrigin = origin
-    if (existingOrigin != null) {
+    if (existingOrigin is ParseTreeOrigin) {
         if (keepRange || keepSourceText) {
             this.origin = SimpleOrigin(
                 if (keepRange) existingOrigin.range else null,
@@ -15,9 +17,6 @@ fun Node.detachFromParseTree(keepRange: Boolean = true, keepSourceText: Boolean 
             )
         } else {
             this.origin = null
-        }
-        if ((existingOrigin is Node) && (this in existingOrigin.destinations)) {
-            existingOrigin.destinations -= this
         }
     }
 }

--- a/antlr/src/main/kotlin/com/strumenta/kolasu/antlr/Utils.kt
+++ b/antlr/src/main/kotlin/com/strumenta/kolasu/antlr/Utils.kt
@@ -1,0 +1,22 @@
+package com.strumenta.kolasu.antlr
+
+import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.NodeDestination
+import com.strumenta.kolasu.model.SimpleOrigin
+
+fun Node.detachFromParseTree(keepRange: Boolean = true, keepSourceText: Boolean = false) {
+    val existingOrigin = origin
+    if (existingOrigin != null) {
+        if (keepRange || keepSourceText) {
+            this.origin = SimpleOrigin(
+                if (keepRange) existingOrigin.range else null,
+                if (keepSourceText) existingOrigin.sourceText else null
+            )
+        } else {
+            this.origin = null
+        }
+        if (existingOrigin is Node && existingOrigin.destinations.contains(NodeDestination(this))) {
+            existingOrigin.destinations.remove(NodeDestination(this))
+        }
+    }
+}

--- a/antlr/src/main/kotlin/com/strumenta/kolasu/antlr/parsing/ANTLRParseTreeUtils.kt
+++ b/antlr/src/main/kotlin/com/strumenta/kolasu/antlr/parsing/ANTLRParseTreeUtils.kt
@@ -72,8 +72,14 @@ fun Node.getText(code: String): String? = range?.text(code)
  * Note that this is NOT serializable as ParseTree elements are not Serializable.
  */
 class ParseTreeOrigin(val parseTree: ParseTree, override var source: Source? = null) : Origin {
-    override val range: Range?
-        get() = parseTree.toRange(source = source)
+
+    private var rangeOverride: Range? = null
+
+    override var range: Range?
+        get() = rangeOverride ?: parseTree.toRange(source = source)
+        set(value) {
+            rangeOverride = value
+        }
 
     override val sourceText: String?
         get() =

--- a/antlr/src/test/kotlin/com/strumenta/kolasu/antlr/model/OriginTest.kt
+++ b/antlr/src/test/kotlin/com/strumenta/kolasu/antlr/model/OriginTest.kt
@@ -1,5 +1,6 @@
 package com.strumenta.kolasu.antlr.model
 
+import com.strumenta.kolasu.antlr.detachFromParseTree
 import com.strumenta.kolasu.antlr.parsing.ParseTreeOrigin
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Point
@@ -34,22 +35,22 @@ class OriginTest {
 
         var node = Node().withOrigin(rootOrigin)
         assertEquals(rootOrigin.range, node.range)
-        node.detach()
+        node.detachFromParseTree()
         assertEquals(rootOrigin.range, node.range)
         node = Node().withOrigin(rootOrigin)
         assertEquals(rootOrigin.range, node.range)
-        node.detach(keepRange = true)
+        node.detachFromParseTree(keepRange = true)
         assertEquals(rootOrigin.range, node.range)
         node = Node().withOrigin(rootOrigin)
         assertEquals(rootOrigin.range, node.range)
-        node.detach(keepRange = false)
+        node.detachFromParseTree(keepRange = false)
         assertNull(node.origin)
         assertNull(node.range)
         node = Node().withOrigin(rootOrigin).withRange(range(1, 2, 3, 4))
         assertEquals(range(1, 2, 3, 4), node.range)
-        node.detach(keepRange = false)
+        node.detachFromParseTree(keepRange = false)
         assertNull(node.origin)
-        assertEquals(range(1, 2, 3, 4), node.range)
+        assertEquals(null, node.range)
     }
 
     @test fun parseTreeOriginsSourceText() {
@@ -70,15 +71,15 @@ class OriginTest {
 
         var node = Node().withOrigin(rootOrigin)
         assertEquals(rootOrigin.sourceText, node.sourceText)
-        node.detach()
+        node.detachFromParseTree()
         assertNull(node.sourceText)
         node = Node().withOrigin(rootOrigin)
         assertEquals(rootOrigin.sourceText, node.sourceText)
-        node.detach(keepSourceText = true)
+        node.detachFromParseTree(keepSourceText = true)
         assertEquals(rootOrigin.sourceText, node.sourceText)
         node = Node().withOrigin(rootOrigin)
         assertEquals(rootOrigin.sourceText, node.sourceText)
-        node.detach(keepSourceText = false)
+        node.detachFromParseTree(keepSourceText = false)
         assertNull(node.sourceText)
     }
 }

--- a/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
@@ -126,7 +126,7 @@ class PrinterOutput(
         generation()
         val endPoint = currentPoint
         val nodeRangeInGeneratedCode = Range(startPoint, endPoint)
-        ast.destination = TextFileDestination(range = nodeRangeInGeneratedCode)
+        ast.destinations.add(TextFileDestination(range = nodeRangeInGeneratedCode))
     }
 
     fun <T : Node> printList(elements: List<T>, separator: String = ", ") {

--- a/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
@@ -126,7 +126,7 @@ class PrinterOutput(
         generation()
         val endPoint = currentPoint
         val nodeRangeInGeneratedCode = Range(startPoint, endPoint)
-        ast.destinations.add(TextFileDestination(range = nodeRangeInGeneratedCode))
+        ast.destinations += TextFileDestination(range = nodeRangeInGeneratedCode)
     }
 
     fun <T : Node> printList(elements: List<T>, separator: String = ", ") {

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Destinations.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Destinations.kt
@@ -8,3 +8,13 @@ data class CompositeDestination(val elements: List<Destination>) : Destination, 
 data class TextFileDestination(val range: Range?) : Destination, Serializable
 
 data class NodeDestination(val node: Node) : Destination
+
+operator fun MutableList<Destination>.plusAssign(node: Node) {
+    this.add(NodeDestination(node))
+}
+
+operator fun MutableList<Destination>.minusAssign(node: Node) {
+    this.remove(NodeDestination(node))
+}
+
+operator fun List<Destination>.contains(node: Node): Boolean = NodeDestination(node) in this

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Destinations.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Destinations.kt
@@ -1,0 +1,10 @@
+package com.strumenta.kolasu.model
+
+import java.io.Serializable
+
+interface Destination
+
+data class CompositeDestination(val elements: List<Destination>) : Destination, Serializable
+data class TextFileDestination(val range: Range?) : Destination, Serializable
+
+data class NodeDestination(val node: Node) : Destination

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Origins.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Origins.kt
@@ -1,0 +1,28 @@
+package com.strumenta.kolasu.model
+
+import java.io.Serializable
+
+interface Origin {
+    var range: Range?
+    val sourceText: String?
+    val source: Source?
+        get() = range?.source
+}
+
+data class SimpleOrigin(override var range: Range?, override val sourceText: String? = null) : Origin, Serializable
+
+data class CompositeOrigin(
+    val elements: List<Origin>,
+    override var range: Range?,
+    override val sourceText: String?
+) : Origin, Serializable
+
+data class NodeOrigin(val node: Node) : Origin {
+    override var range: Range?
+        get() = node.range
+        set(value) {
+            node.range = value
+        }
+    override val sourceText: String?
+        get() = node.sourceText
+}

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
@@ -2,6 +2,7 @@ package com.strumenta.kolasu.transformation
 
 import com.strumenta.kolasu.model.GenericErrorNode
 import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.NodeOrigin
 import com.strumenta.kolasu.model.Origin
 import com.strumenta.kolasu.model.PropertyTypeDescription
 import com.strumenta.kolasu.model.Range
@@ -407,6 +408,13 @@ open class ASTTransformer(
         return registerNodeTransformer(S::class, T::class)
     }
 
+    private fun <N : Node>N.settingOrigin(source: Any): N {
+        if (source is Node) {
+            this.origin = NodeOrigin(source)
+        }
+        return this
+    }
+
     fun <S : Any, T : Node> registerNodeTransformer(
         source: KClass<S>,
         target: KClass<T>,
@@ -481,7 +489,7 @@ open class ASTTransformer(
                     try {
                         val instance = constructor.callBy(constructorParamValues)
                         instance.children.forEach { child -> child.parent = instance }
-                        instance
+                        instance.settingOrigin(source)
                     } catch (t: Throwable) {
                         throw RuntimeException(
                             "Invocation of constructor $constructor failed. " +
@@ -499,7 +507,7 @@ open class ASTTransformer(
                                 "constructor for $target"
                         )
                     }
-                    target.createInstance()
+                    target.createInstance().settingOrigin(source)
                 }
             },
             // If I do not have an emptyLikeConstructor, then I am forced to invoke a constructor with parameters and

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
@@ -408,7 +408,11 @@ open class ASTTransformer(
         return registerNodeTransformer(S::class, T::class)
     }
 
-    private fun <N : Node>N.settingOrigin(source: Any): N {
+    /**
+     * Define the origin of the node as the source, but only if source is a Node, otherwise
+     * this method does not do anything.
+     */
+    private fun <N : Node>N.settingNodeOrigin(source: Any): N {
         if (source is Node) {
             this.origin = NodeOrigin(source)
         }
@@ -489,7 +493,7 @@ open class ASTTransformer(
                     try {
                         val instance = constructor.callBy(constructorParamValues)
                         instance.children.forEach { child -> child.parent = instance }
-                        instance.settingOrigin(source)
+                        instance.settingNodeOrigin(source)
                     } catch (t: Throwable) {
                         throw RuntimeException(
                             "Invocation of constructor $constructor failed. " +
@@ -507,7 +511,7 @@ open class ASTTransformer(
                                 "constructor for $target"
                         )
                     }
-                    target.createInstance().settingOrigin(source)
+                    target.createInstance().settingNodeOrigin(source)
                 }
             },
             // If I do not have an emptyLikeConstructor, then I am forced to invoke a constructor with parameters and

--- a/core/src/test/kotlin/com/strumenta/kolasu/transformation/ASTTransformerTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/transformation/ASTTransformerTest.kt
@@ -271,7 +271,7 @@ class ASTTransformerTest {
         transformer.registerNodeTransformer(CU::class, CU::class)
             .withChild(CU::statements, CU::statements)
         transformer.registerNodeTransformer(DisplayIntStatement::class) { s ->
-            s.withOrigin(NodeOrigin(GenericNode()))
+            s.withOrigin(GenericNode())
         }
 
         val cu = CU(

--- a/core/src/test/kotlin/com/strumenta/kolasu/transformation/ASTTransformerTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/transformation/ASTTransformerTest.kt
@@ -1,6 +1,7 @@
 package com.strumenta.kolasu.transformation
 
 import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.NodeOrigin
 import com.strumenta.kolasu.model.Range
 import com.strumenta.kolasu.model.hasValidParents
 import com.strumenta.kolasu.model.withOrigin
@@ -74,7 +75,7 @@ class ASTTransformerTest {
         val transformedCU = transformer.transform(cu)!!
         assertASTsAreEqual(cu, transformedCU, considerRange = true)
         assertTrue { transformedCU.hasValidParents() }
-        assertEquals(transformedCU.origin, cu)
+        assertEquals(NodeOrigin(cu), transformedCU.origin)
     }
 
     /**
@@ -259,7 +260,7 @@ class ASTTransformerTest {
         )
         val transformedCU = transformer.transform(cu)!! as CU
         assertTrue { transformedCU.hasValidParents() }
-        assertEquals(transformedCU.origin, cu)
+        assertEquals(transformedCU.origin, NodeOrigin(cu))
         assertEquals(1, transformedCU.statements.size)
         assertASTsAreEqual(cu.statements[1], transformedCU.statements[0])
     }
@@ -270,7 +271,7 @@ class ASTTransformerTest {
         transformer.registerNodeTransformer(CU::class, CU::class)
             .withChild(CU::statements, CU::statements)
         transformer.registerNodeTransformer(DisplayIntStatement::class) { s ->
-            s.withOrigin(GenericNode())
+            s.withOrigin(NodeOrigin(GenericNode()))
         }
 
         val cu = CU(
@@ -280,7 +281,7 @@ class ASTTransformerTest {
         )
         val transformedCU = transformer.transform(cu)!! as CU
         assertTrue { transformedCU.hasValidParents() }
-        assertEquals(transformedCU.origin, cu)
-        assertIs<GenericNode>(transformedCU.statements[0].origin)
+        assertEquals(transformedCU.origin, NodeOrigin(cu))
+        assertIs<GenericNode>((transformedCU.statements[0].origin as NodeOrigin).node)
     }
 }

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/Model.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/Model.kt
@@ -5,6 +5,8 @@ import com.google.gson.JsonParser
 import com.strumenta.kolasu.antlr.parsing.ParseTreeOrigin
 import com.strumenta.kolasu.model.Destination
 import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.NodeDestination
+import com.strumenta.kolasu.model.NodeOrigin
 import com.strumenta.kolasu.model.Origin
 import com.strumenta.kolasu.model.Point
 import com.strumenta.kolasu.model.Range
@@ -338,11 +340,11 @@ private fun setOrigin(
     val astNode = STARLASU_METAMODEL.getEClass("ASTNode")
     val originSF = astNode.getEStructuralFeature("origin")
     when (origin) {
-        is Node -> {
+        is NodeOrigin -> {
             val nodeOriginClass = STARLASU_METAMODEL.getEClass("NodeOrigin")
             val nodeSF = nodeOriginClass.getEStructuralFeature("node")
             val nodeOrigin = nodeOriginClass.instantiate()
-            val eoCorrespondingToOrigin = mapping.getAssociatedEObject(origin) ?: throw IllegalStateException(
+            val eoCorrespondingToOrigin = mapping.getAssociatedEObject(origin.node) ?: throw IllegalStateException(
                 "No EObject mapped to origin $origin. " +
                     "Mapping contains ${mapping.size} entries"
             )
@@ -378,12 +380,12 @@ private fun setDestination(
     val astNode = STARLASU_METAMODEL.getEClass("ASTNode")
     when (destination) {
         null -> return
-        is Node -> {
+        is NodeDestination -> {
             val nodeDestination = STARLASU_METAMODEL.getEClass("NodeDestination")
 
             val nodeDestinationInstance = nodeDestination.instantiate()
             val nodeSF = nodeDestination.getEStructuralFeature("node")
-            val eoCorrespondingToOrigin = destination.getOrCreateEObject(eResource, mapping)
+            val eoCorrespondingToOrigin = destination.node.getOrCreateEObject(eResource, mapping)
             nodeDestinationInstance.eSet(nodeSF, eoCorrespondingToOrigin)
 
             val destinationSF = astNode.getEStructuralFeature("destination")
@@ -428,7 +430,8 @@ fun Node.toEObject(eResource: Resource, mapping: KolasuToEMFMapping = KolasuToEM
         eo.eSet(positionSF, rangeValue)
 
         setOrigin(eo, this.origin, eResource, mapping)
-        setDestination(eo, this.destination, eResource, mapping)
+        require(this.destinations.size < 2)
+        setDestination(eo, this.destinations.firstOrNull(), eResource, mapping)
 
         this.processProperties { pd ->
             val esf = ec.eAllStructuralFeatures.find { it.name == pd.name }!!

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/ModelTest.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/ModelTest.kt
@@ -2,7 +2,6 @@ package com.strumenta.kolasu.emf
 
 import com.strumenta.kolasu.antlr.parsing.withParseTreeNode
 import com.strumenta.kolasu.model.Node
-import com.strumenta.kolasu.model.NodeOrigin
 import com.strumenta.kolasu.model.Point
 import com.strumenta.kolasu.model.Range
 import com.strumenta.kolasu.model.ReferenceByName
@@ -119,9 +118,7 @@ class ModelTest {
     @Test
     fun originIsSerialized() {
         val n1 = NodeFoo("abc")
-        val n2 = NodeFoo("def").apply {
-            origin = NodeOrigin(n1)
-        }
+        val n2 = NodeFoo("def").withOrigin(n1)
         val ePackage = MetamodelBuilder("com.strumenta.kolasu.emf", "http://foo.com", "foo")
             .apply {
                 provideClass(NodeFoo::class)

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/ModelTest.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/ModelTest.kt
@@ -141,7 +141,7 @@ class ModelTest {
     @Test
     fun destinationIsSerialized() {
         val n1 = NodeFoo("abc").apply {
-            destinations.add(TextFileDestination(Range(Point(1, 8), Point(7, 4))))
+            destinations += TextFileDestination(Range(Point(1, 8), Point(7, 4)))
         }
         val ePackage = MetamodelBuilder("com.strumenta.kolasu.emf", "http://foo.com", "foo").apply {
             provideClass(NodeFoo::class)

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/ModelTest.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/ModelTest.kt
@@ -2,6 +2,7 @@ package com.strumenta.kolasu.emf
 
 import com.strumenta.kolasu.antlr.parsing.withParseTreeNode
 import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.NodeOrigin
 import com.strumenta.kolasu.model.Point
 import com.strumenta.kolasu.model.Range
 import com.strumenta.kolasu.model.ReferenceByName
@@ -119,7 +120,7 @@ class ModelTest {
     fun originIsSerialized() {
         val n1 = NodeFoo("abc")
         val n2 = NodeFoo("def").apply {
-            origin = n1
+            origin = NodeOrigin(n1)
         }
         val ePackage = MetamodelBuilder("com.strumenta.kolasu.emf", "http://foo.com", "foo")
             .apply {
@@ -140,7 +141,7 @@ class ModelTest {
     @Test
     fun destinationIsSerialized() {
         val n1 = NodeFoo("abc").apply {
-            destination = TextFileDestination(Range(Point(1, 8), Point(7, 4)))
+            destinations.add(TextFileDestination(Range(Point(1, 8), Point(7, 4))))
         }
         val ePackage = MetamodelBuilder("com.strumenta.kolasu.emf", "http://foo.com", "foo").apply {
             provideClass(NodeFoo::class)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=1.6.0-RC1-observers-SNAPSHOT
 kotlin_version=1.8.21
 dokka_version=1.8.10
-antlr_version=4.12.0
+antlr_version=4.9.3
 clikt_version=3.5.2
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 jvm_version=1.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=1.6.0-RC1-observers-SNAPSHOT
 kotlin_version=1.8.21
 dokka_version=1.8.10
-antlr_version=4.9.3
+antlr_version=4.12.0
 clikt_version=3.5.2
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 jvm_version=1.8

--- a/playground/src/test/kotlin/com/strumenta/kolasu/playground/TranspilationTraceTest.kt
+++ b/playground/src/test/kotlin/com/strumenta/kolasu/playground/TranspilationTraceTest.kt
@@ -1,6 +1,8 @@
 package com.strumenta.kolasu.playground
 
 import com.strumenta.kolasu.emf.MetamodelBuilder
+import com.strumenta.kolasu.model.NodeDestination
+import com.strumenta.kolasu.model.NodeOrigin
 import com.strumenta.kolasu.validation.Issue
 import com.strumenta.kolasu.validation.IssueSeverity
 import com.strumenta.kolasu.validation.IssueType
@@ -132,8 +134,8 @@ class TranspilationTraceTest {
     fun serializeSourceAndDestination() {
         val aRoot = ANode("a", 1)
         val bRoot = ANode("b", 2)
-        aRoot.destination = bRoot
-        bRoot.origin = aRoot
+        aRoot.destinations.add(NodeDestination(bRoot))
+        bRoot.origin = NodeOrigin(aRoot)
         val tt = TranspilationTrace(
             "a:1",
             "b:2",

--- a/playground/src/test/kotlin/com/strumenta/kolasu/playground/TranspilationTraceTest.kt
+++ b/playground/src/test/kotlin/com/strumenta/kolasu/playground/TranspilationTraceTest.kt
@@ -1,8 +1,8 @@
 package com.strumenta.kolasu.playground
 
 import com.strumenta.kolasu.emf.MetamodelBuilder
-import com.strumenta.kolasu.model.NodeOrigin
 import com.strumenta.kolasu.model.plusAssign
+import com.strumenta.kolasu.model.withOrigin
 import com.strumenta.kolasu.validation.Issue
 import com.strumenta.kolasu.validation.IssueSeverity
 import com.strumenta.kolasu.validation.IssueType
@@ -135,7 +135,7 @@ class TranspilationTraceTest {
         val aRoot = ANode("a", 1)
         val bRoot = ANode("b", 2)
         aRoot.destinations += bRoot
-        bRoot.origin = NodeOrigin(aRoot)
+        bRoot.withOrigin(aRoot)
         val tt = TranspilationTrace(
             "a:1",
             "b:2",

--- a/playground/src/test/kotlin/com/strumenta/kolasu/playground/TranspilationTraceTest.kt
+++ b/playground/src/test/kotlin/com/strumenta/kolasu/playground/TranspilationTraceTest.kt
@@ -1,8 +1,8 @@
 package com.strumenta.kolasu.playground
 
 import com.strumenta.kolasu.emf.MetamodelBuilder
-import com.strumenta.kolasu.model.NodeDestination
 import com.strumenta.kolasu.model.NodeOrigin
+import com.strumenta.kolasu.model.plusAssign
 import com.strumenta.kolasu.validation.Issue
 import com.strumenta.kolasu.validation.IssueSeverity
 import com.strumenta.kolasu.validation.IssueType
@@ -134,7 +134,7 @@ class TranspilationTraceTest {
     fun serializeSourceAndDestination() {
         val aRoot = ANode("a", 1)
         val bRoot = ANode("b", 2)
-        aRoot.destinations.add(NodeDestination(bRoot))
+        aRoot.destinations += bRoot
         bRoot.origin = NodeOrigin(aRoot)
         val tt = TranspilationTrace(
             "a:1",


### PR DESCRIPTION
The node itself now contains exclusively the data but not the position or the source. They are part of the origin of the node.
The node has accessors to simplify getting access to them.

- rangeOverride is moved to the ParseTreeOrigin.

- detach is renamed in detachFromParseTree, because detach could be interpreted as "remove the node from the AST" (i.e., set its parent to null.

- destinations and origins are moved to separate files

- the Node is now not anymore an Origin or a Destination, both still it can be used almost as an Origin or a Destination by means of a few operators being added in Destinations.kt and overloaded methods such as `Node.withOrigin(Node)`

Fix #194 