### PR TITLE
Adding ASTTransformer.notTranslateDirectly

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
@@ -459,9 +459,11 @@ open class ASTTransformer(
     }
 
     fun <S : Any> notTranslateDirectly(): NodeFactory<S, Node> {
-        throw java.lang.IllegalStateException("A Node of this type should never be translated directly. " +
+        throw java.lang.IllegalStateException(
+            "A Node of this type should never be translated directly. " +
                 "It is expected that the container will not delegate the translation of this node but it will " +
-                "handle it directly")
+                "handle it directly"
+        )
     }
 
     fun <S : Any, T : Node> registerNodeFactory(source: KClass<S>, target: KClass<T>): NodeFactory<S, T> {

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
@@ -458,6 +458,12 @@ open class ASTTransformer(
         return registerNodeFactory(S::class, T::class)
     }
 
+    fun <S : Any> notTranslateDirectly(): NodeFactory<S, Node> {
+        throw java.lang.IllegalStateException("A Node of this type should never be translated directly. " +
+                "It is expected that the container will not delegate the translation of this node but it will " +
+                "handle it directly")
+    }
+
     fun <S : Any, T : Node> registerNodeFactory(source: KClass<S>, target: KClass<T>): NodeFactory<S, T> {
         registerKnownClass(target)
         // We are looking for any constructor with does not take parameters or have default


### PR DESCRIPTION
This method has the purpose to indicate that something should not be translated directly. 

For example, if "b" appears in a grammar only within "a", and when translating "a" we also process all children of type "b", then we will never need to translate "b" directly. This is the often case for example for simple lists representing lists, like lists of parameters. In the method declarations we may process this list and possibly trigger the translation of the single parameters but not of the sub-rule defining the parameter lists.

This explicit "non-mapping" has two benefits:
1. Produce a better error message
2. Could be detected by a plugin used to check that we map all elements