### PR TITLE
Supporting the recognition of internal classes when mapping to EMF

### DIFF
--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/Metamodel.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/Metamodel.kt
@@ -115,7 +115,7 @@ val KClass<*>.eClassifierName: String
 
 val Class<*>.eClassifierName: String
     get() = if (this.enclosingClass != null) {
-        "${this.enclosingClass.simpleName}${this.simpleName}"
+        "${this.enclosingClass.simpleName}.${this.simpleName}"
     } else {
         this.simpleName
     }

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
@@ -1,6 +1,7 @@
 package com.strumenta.kolasu.emf
 
 import com.strumenta.kolasu.model.PropertyTypeDescription
+import com.strumenta.kolasu.model.isANode
 import com.strumenta.kolasu.model.processProperties
 import org.eclipse.emf.ecore.*
 import org.eclipse.emf.ecore.resource.Resource
@@ -13,12 +14,23 @@ import kotlin.reflect.full.withNullability
 
 private val KClass<*>.packageName: String?
     get() {
-        val qname = this.qualifiedName ?: throw IllegalStateException("The class has no qualified name: $this")
+        val isInternal = this.java.name.contains('$')
+        val qname = if (isInternal) {
+            this.java.name.split("$").first()
+        } else {
+            this.qualifiedName ?: throw IllegalStateException("The class has no qualified name: $this")
+        }
         return if (qname == this.simpleName) {
             null
         } else {
-            require(qname.endsWith(".${this.simpleName}"))
-            qname.removeSuffix(".${this.simpleName}")
+            if (isInternal) {
+                val last = qname.split(".").last()
+                require(qname.endsWith(".$last"))
+                qname.removeSuffix(".$last")
+            } else {
+                require(qname.endsWith(".${this.simpleName}"))
+                qname.removeSuffix(".${this.simpleName}")
+            }
         }
     }
 
@@ -344,6 +356,11 @@ class MetamodelBuilder(packageName: String, nsURI: String, nsPrefix: String, res
             registerKClassForEClass(kClass, eClass)
             if (kClass.isSealed) {
                 kClass.sealedSubclasses.forEach {
+                    queue.add(it)
+                }
+            }
+            kClass.nestedClasses.forEach {
+                if (it.isANode()) {
                     queue.add(it)
                 }
             }

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/MetamodelTest.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/MetamodelTest.kt
@@ -148,7 +148,6 @@ class MetamodelTest {
         )
         metamodelBuilder.provideClass(NodeWithReference::class)
         val ePackage = metamodelBuilder.generate()
-        println(ePackage.saveAsJsonObject().toString())
         assertEquals("com.strumenta.kolasu.emf", ePackage.name)
         assertEquals(1, ePackage.eClassifiers.size)
 
@@ -162,4 +161,26 @@ class MetamodelTest {
         val pointers = nodeWithReference.eStructuralFeatures.find { it.name == "pointers" } as EReference
         assertEquals(true, pointers.isContainment)
     }
+
+    @Test
+    fun internalClasses() {
+        val metamodelBuilder = MetamodelBuilder(
+            "com.strumenta.kolasu.emf",
+            "https://strumenta.com/simplemm", "simplemm"
+        )
+        metamodelBuilder.provideClass(MyClassWithInternalClasses::class)
+        val ePackage = metamodelBuilder.generate()
+        assertEquals("com.strumenta.kolasu.emf", ePackage.name)
+        assertEquals(2, ePackage.eClassifiers.size)
+        val MyClassWithInternalClasses = ePackage.eClassifiers[0]
+        val Internal = ePackage.eClassifiers[1]
+        assertEquals("MyClassWithInternalClasses", MyClassWithInternalClasses.name)
+        assertEquals("MyClassWithInternalClasses.Internal", Internal.name)
+    }
+}
+
+class MyClassWithInternalClasses : Node() {
+    class Internal : Node()
+
+    class InternalWhichIsNotANode
 }


### PR DESCRIPTION
Without this change internal classes are considered to belong to a separate package. For example, a class Foo defined in a class a.b.Bar, will appear to belong to the package a.b.Bar. With this change it is recognized to belong to the package a.b, and it will have name Bar.Foo.

This is useful to generate documentation that looks like this:

<img width="1790" alt="Screenshot 2023-07-04 at 11 29 55" src="https://github.com/Strumenta/kolasu/assets/439078/43ca56c5-e427-426c-94d7-9fca0854b123">
