### PR TITLE
Tentative fix to deal with issues using generateJSONWithStreaming

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/serialization/JsonDeserializer.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/serialization/JsonDeserializer.kt
@@ -41,7 +41,19 @@ class JsonDeserializer {
                     val actualClass = try {
                         Class.forName(className)
                     } catch (ex: ClassNotFoundException) {
-                        Class.forName(rawClass.`package`.name + "." + className)
+                        // This handles only the case when the serialized JSON used the simple name
+                        // rather than the canonical name for indicating the type of the serialized object.
+                        // The rawClass is the class we are expecting,
+                        // while className is the type in the JSON serialization.
+                        // These two types could be different: rawClass could be a sealed or abstract type,
+                        // while className could be a compatible concrete class.
+                        // So, when className is a simple name and we cannot resolve it directly,
+                        // we need to get the package name of the rawClass and apply it to className.
+                        Class.forName(
+                            "${rawClass.canonicalName.substring(
+                                0, rawClass.canonicalName.lastIndexOf('.') + 1
+                            )}$className"
+                        )
                     }
                     return deserialize(actualClass.asSubclass(Node::class.java), json.asJsonObject)
                 }

--- a/core/src/main/kotlin/com/strumenta/kolasu/serialization/JsonDeserializer.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/serialization/JsonDeserializer.kt
@@ -38,7 +38,11 @@ class JsonDeserializer {
             when {
                 Node::class.java.isAssignableFrom(rawClass) -> {
                     val className = json.asJsonObject[JSON_TYPE_KEY].asString
-                    val actualClass = Class.forName(className)
+                    val actualClass = try {
+                        Class.forName(className)
+                    } catch (ex: ClassNotFoundException) {
+                        Class.forName(rawClass.`package`.name + "." + className)
+                    }
                     return deserialize(actualClass.asSubclass(Node::class.java), json.asJsonObject)
                 }
                 Collection::class.java.isAssignableFrom(rawClass) -> {

--- a/core/src/main/kotlin/com/strumenta/kolasu/serialization/JsonGenerator.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/serialization/JsonGenerator.kt
@@ -127,17 +127,17 @@ class JsonGenerator {
         writer.beginArray()
         result.issues.forEach { it.toJsonStreaming(writer) }
         writer.endArray()
-        writer.name("root")
         if (result.root == null) {
-            writer.nullValue()
+            // do nothing for consistency with non-streaming JSON generation
         } else {
+            writer.name("root")
             generateJSONWithStreaming(result.root, writer, shortClassNames)
         }
         writer.endObject()
     }
 
     fun generateJSONWithStreaming(root: Node, writer: JsonWriter, shortClassNames: Boolean = false) {
-        val gson = gsonBuilder.setPrettyPrinting().create()
+        val gson = gsonBuilder.create()
         gson.toJson(
             generateJSON(
                 root = root,
@@ -374,6 +374,8 @@ private fun Issue.toJsonStreaming(writer: JsonWriter) {
     writer.value(this.type.name)
     writer.name("message")
     writer.value(this.message)
+    writer.name("severity")
+    writer.value(this.severity.name)
     writer.name("position")
     if (this.position == null) {
         writer.nullValue()

--- a/core/src/main/kotlin/com/strumenta/kolasu/serialization/JsonGenerator.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/serialization/JsonGenerator.kt
@@ -138,7 +138,16 @@ class JsonGenerator {
 
     fun generateJSONWithStreaming(root: Node, writer: JsonWriter, shortClassNames: Boolean = false) {
         val gson = gsonBuilder.setPrettyPrinting().create()
-        gson.toJson(generateJSON(root = root, withIds = null, withOriginIds = null, withDestinationIds = null, shortClassNames = shortClassNames), writer)
+        gson.toJson(
+            generateJSON(
+                root = root,
+                withIds = null,
+                withOriginIds = null,
+                withDestinationIds = null,
+                shortClassNames = shortClassNames
+            ),
+            writer
+        )
     }
 
     fun generateString(root: Node, withIds: IdentityHashMap<Node, String>? = null): String {

--- a/core/src/main/kotlin/com/strumenta/kolasu/serialization/JsonGenerator.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/serialization/JsonGenerator.kt
@@ -138,7 +138,7 @@ class JsonGenerator {
 
     fun generateJSONWithStreaming(root: Node, writer: JsonWriter, shortClassNames: Boolean = false) {
         val gson = gsonBuilder.setPrettyPrinting().create()
-        gson.toJson(generateJSON(root, null, null, null, shortClassNames), writer)
+        gson.toJson(generateJSON(root = root, withIds = null, withOriginIds = null, withDestinationIds = null, shortClassNames = shortClassNames), writer)
     }
 
     fun generateString(root: Node, withIds: IdentityHashMap<Node, String>? = null): String {

--- a/core/src/main/kotlin/com/strumenta/kolasu/serialization/JsonGenerator.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/serialization/JsonGenerator.kt
@@ -82,7 +82,8 @@ class JsonGenerator {
         root: Node,
         withIds: IdentityHashMap<Node, String>? = null,
         withOriginIds: IdentityHashMap<Node, String>? = null,
-        withDestinationIds: IdentityHashMap<Node, String>? = null
+        withDestinationIds: IdentityHashMap<Node, String>? = null,
+        shortClassNames: Boolean = false
     ): JsonElement {
         return nodeToJson(
             root, shortClassNames,
@@ -130,27 +131,28 @@ class JsonGenerator {
         if (result.root == null) {
             writer.nullValue()
         } else {
-            result.root.toJsonStreaming(writer, shortClassNames)
+            generateJSONWithStreaming(result.root, writer, shortClassNames)
         }
         writer.endObject()
     }
 
     fun generateJSONWithStreaming(root: Node, writer: JsonWriter, shortClassNames: Boolean = false) {
-        root.toJsonStreaming(writer, shortClassNames)
+        val gson = gsonBuilder.setPrettyPrinting().create()
+        gson.toJson(generateJSON(root, null, null, null, shortClassNames), writer)
     }
 
     fun generateString(root: Node, withIds: IdentityHashMap<Node, String>? = null): String {
-        val gson = GsonBuilder().setPrettyPrinting().create()
+        val gson = gsonBuilder.setPrettyPrinting().create()
         return gson.toJson(generateJSON(root, withIds))
     }
 
     fun generateString(result: Result<out Node>, withIds: IdentityHashMap<Node, String>? = null): String {
-        val gson = GsonBuilder().setPrettyPrinting().create()
+        val gson = gsonBuilder.setPrettyPrinting().create()
         return gson.toJson(generateJSON(result, withIds))
     }
 
     fun generateString(result: ParsingResult<out Node>, withIds: IdentityHashMap<Node, String>? = null): String {
-        val gson = GsonBuilder().setPrettyPrinting().create()
+        val gson = gsonBuilder.setPrettyPrinting().create()
         return gson.toJson(generateJSON(result, withIds))
     }
 

--- a/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonDeserializerTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonDeserializerTest.kt
@@ -1,11 +1,13 @@
 package com.strumenta.kolasu.serialization
 
+import com.google.gson.stream.JsonWriter
 import com.strumenta.kolasu.model.Point
 import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.validation.Issue
 import com.strumenta.kolasu.validation.IssueType
 import com.strumenta.kolasu.validation.Result
 import org.junit.Test
+import java.io.StringWriter
 import kotlin.test.assertEquals
 
 class JsonDeserializerTest {
@@ -58,6 +60,82 @@ class JsonDeserializerTest {
             null,
         )
         val json = JsonGenerator().generateString(originalResult)
+        val deserialized: Result<MyRoot> = JsonDeserializer().deserializeResult(MyRoot::class.java, json)
+        assertEquals(originalResult, deserialized)
+    }
+
+    @Test
+    fun deserializeNodeFromStreaming() {
+        val myRoot = MyRoot(
+            mainSection = Section(
+                "Section1",
+                listOf(
+                    Content(1, null),
+                    Content(2, Content(3, Content(4, null))),
+                ),
+            ),
+            otherSections = listOf(),
+        )
+        val writer = StringWriter()
+        JsonGenerator().generateJSONWithStreaming(root = myRoot, writer = JsonWriter(writer))
+        val json = writer.toString()
+        val deserialized = JsonDeserializer().deserialize(MyRoot::class.java, json)
+        assertEquals(myRoot, deserialized)
+    }
+
+    @Test
+    fun deserializeNodeFromStreamingWithShortNames() {
+        val myRoot = MyRoot(
+            mainSection = Section(
+                "Section1",
+                listOf(
+                    Content(1, null),
+                    Content(2, Content(3, Content(4, null))),
+                ),
+            ),
+            otherSections = listOf(),
+        )
+        val writer = StringWriter()
+        JsonGenerator().generateJSONWithStreaming(root = myRoot, writer = JsonWriter(writer), shortClassNames = true)
+        val json = writer.toString()
+        val deserialized = JsonDeserializer().deserialize(MyRoot::class.java, json)
+        assertEquals(myRoot, deserialized)
+    }
+
+    @Test
+    fun deserializeNegativeResultFromJsonStreaming() {
+        val originalResult: Result<MyRoot> = Result(
+            listOf(
+                Issue(
+                    IssueType.LEXICAL,
+                    "foo",
+                    position = Position(Point(1, 10), Point(4, 540)),
+                ),
+            ),
+            null,
+        )
+        val writer = StringWriter()
+        JsonGenerator().generateJSONWithStreaming(result = originalResult, writer = JsonWriter(writer), shortClassNames = false)
+        val json = writer.toString()
+        val deserialized: Result<MyRoot> = JsonDeserializer().deserializeResult(MyRoot::class.java, json)
+        assertEquals(originalResult, deserialized)
+    }
+
+    @Test
+    fun deserializeNegativeResultFromJsonStreamingWithShortNames() {
+        val originalResult: Result<MyRoot> = Result(
+            listOf(
+                Issue(
+                    IssueType.LEXICAL,
+                    "foo",
+                    position = Position(Point(1, 10), Point(4, 540)),
+                ),
+            ),
+            null,
+        )
+        val writer = StringWriter()
+        JsonGenerator().generateJSONWithStreaming(result = originalResult, writer = JsonWriter(writer), shortClassNames = true)
+        val json = writer.toString()
         val deserialized: Result<MyRoot> = JsonDeserializer().deserializeResult(MyRoot::class.java, json)
         assertEquals(originalResult, deserialized)
     }

--- a/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonDeserializerTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonDeserializerTest.kt
@@ -115,7 +115,11 @@ class JsonDeserializerTest {
             null,
         )
         val writer = StringWriter()
-        JsonGenerator().generateJSONWithStreaming(result = originalResult, writer = JsonWriter(writer), shortClassNames = false)
+        JsonGenerator().generateJSONWithStreaming(
+            result = originalResult,
+            writer = JsonWriter(writer),
+            shortClassNames = false
+        )
         val json = writer.toString()
         val deserialized: Result<MyRoot> = JsonDeserializer().deserializeResult(MyRoot::class.java, json)
         assertEquals(originalResult, deserialized)
@@ -134,7 +138,11 @@ class JsonDeserializerTest {
             null,
         )
         val writer = StringWriter()
-        JsonGenerator().generateJSONWithStreaming(result = originalResult, writer = JsonWriter(writer), shortClassNames = true)
+        JsonGenerator().generateJSONWithStreaming(
+            result = originalResult,
+            writer = JsonWriter(writer),
+            shortClassNames = true
+        )
         val json = writer.toString()
         val deserialized: Result<MyRoot> = JsonDeserializer().deserializeResult(MyRoot::class.java, json)
         assertEquals(originalResult, deserialized)

--- a/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonGenerationTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonGenerationTest.kt
@@ -230,7 +230,11 @@ class JsonGenerationTest {
             null,
         )
         val writer = StringWriter()
-        JsonGenerator().generateJSONWithStreaming(result = originalResult, writer = JsonWriter(writer), shortClassNames = true)
+        JsonGenerator().generateJSONWithStreaming(
+            result = originalResult,
+            writer = JsonWriter(writer),
+            shortClassNames = true
+        )
         val json = writer.toString()
         assertEquals(
             """{"issues":[{"type":"LEXICAL","message":"foo","severity":"ERROR","position":{"description":"Position(start=Line 1, Column 10,

--- a/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonGenerationTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonGenerationTest.kt
@@ -125,6 +125,99 @@ class JsonGenerationTest {
     }
 
     @Test
+    fun generateJsonWithStreamingShortNames() {
+        val myRoot = MyRoot(
+            mainSection = Section(
+                "Section1",
+                listOf(
+                    Content(1, null),
+                    Content(2, Content(3, Content(4, null))),
+                ),
+            ),
+            otherSections = listOf(),
+        )
+        val writer = StringWriter()
+        JsonGenerator().generateJSONWithStreaming(root = myRoot, writer = JsonWriter(writer), shortClassNames = true)
+        val json = writer.toString()
+        assertEquals(
+            """{"#type":"MyRoot",
+                |"mainSection":{"#type":"Section","contents":
+                |[{"#type":"Content","id":1},
+                |{"#type":"Content","annidatedContent":{"#type":"Content",
+                |"annidatedContent":{"#type":"Content","id":4},"id":3},"id":2}],
+                |"name":"Section1"},"otherSections":[]}
+            """.trimMargin().replace("\n", ""),
+            json,
+        )
+    }
+
+    @Test
+    fun nodeWithReferenceStreaming() {
+        val node = NodeWithReference(name = "nodeWithReference", reference = ReferenceByName(name = "self"))
+        val writer = StringWriter()
+        JsonGenerator().generateJSONWithStreaming(node, JsonWriter(writer))
+        val json = writer.toString()
+        assertEquals(
+            """{
+            |"#type":"com.strumenta.kolasu.serialization.NodeWithReference",
+            |"children":[],
+            |"name":"nodeWithReference",
+            |"reference":{
+            |"name":"self"
+            |}
+            |}
+            """.trimMargin().replace("\n", ""),
+            json,
+        )
+    }
+
+    @Test
+    fun nodeWithReferenceStreamingShortNames() {
+        val node = NodeWithReference(name = "nodeWithReference", reference = ReferenceByName(name = "self"))
+        val writer = StringWriter()
+        JsonGenerator().generateJSONWithStreaming(root = node, writer = JsonWriter(writer), shortClassNames = true)
+        val json = writer.toString()
+        assertEquals(
+            """{
+            |"#type":"NodeWithReference",
+            |"children":[],
+            |"name":"nodeWithReference",
+            |"reference":{
+            |"name":"self"
+            |}
+            |}
+            """.trimMargin().replace("\n", ""),
+            json,
+        )
+    }
+
+    @Test
+    fun duplicatePropertiesStreaming() {
+        val node = NodeOverridingName("foo")
+        val writer = StringWriter()
+        JsonGenerator().generateJSONWithStreaming(root = node, writer = JsonWriter(writer))
+        val json = writer.toString()
+        assertEquals(
+            """{"#type":"com.strumenta.kolasu.model.NodeOverridingName","name":"foo"}
+            """.trimMargin().replace("\n", ""),
+            json,
+        )
+    }
+
+    @Test
+    fun duplicatePropertiesStreamingShortNames() {
+        val node = NodeOverridingName("foo")
+        val writer = StringWriter()
+        JsonGenerator().generateJSONWithStreaming(root = node, writer = JsonWriter(writer), shortClassNames = true)
+        val json = writer.toString()
+        assertEquals(
+            """{"#type":"NodeOverridingName","name":"foo"}
+            """.trimMargin().replace("\n", ""),
+            json,
+        )
+    }
+
+    @Test
     fun duplicatePropertiesInheritedByInterface() {
         val json = JsonGenerator().generateString(NodeOverridingName("foo"))
         assertEquals(

--- a/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonGenerationTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonGenerationTest.kt
@@ -218,6 +218,29 @@ class JsonGenerationTest {
     }
 
     @Test
+    fun streamingANullRoot() {
+        val originalResult: Result<MyRoot> = Result(
+            listOf(
+                Issue(
+                    IssueType.LEXICAL,
+                    "foo",
+                    position = Position(Point(1, 10), Point(4, 540)),
+                ),
+            ),
+            null,
+        )
+        val writer = StringWriter()
+        JsonGenerator().generateJSONWithStreaming(result = originalResult, writer = JsonWriter(writer), shortClassNames = true)
+        val json = writer.toString()
+        assertEquals(
+            """{"issues":[{"type":"LEXICAL","message":"foo","severity":"ERROR","position":{"description":"Position(start=Line 1, Column 10,
+               | end=Line 4, Column 540)","start":{"line":1,"column":10},"end":{"line":4,"column":540}}}]}
+            """.trimMargin().replace("\n", ""),
+            json,
+        )
+    }
+
+    @Test
     fun duplicatePropertiesInheritedByInterface() {
         val json = JsonGenerator().generateString(NodeOverridingName("foo"))
         assertEquals(

--- a/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonGenerationTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonGenerationTest.kt
@@ -115,10 +115,9 @@ class JsonGenerationTest {
         assertEquals(
             """{"#type":"com.strumenta.kolasu.serialization.MyRoot",
                 |"mainSection":{"#type":"com.strumenta.kolasu.serialization.Section","contents":
-                |[{"#type":"com.strumenta.kolasu.serialization.Content","annidatedContent":null,"id":1},
-                |{"#type":"com.strumenta.kolasu.serialization.Content","annidatedContent":
-                |{"#type":"com.strumenta.kolasu.serialization.Content","annidatedContent":
-                |{"#type":"com.strumenta.kolasu.serialization.Content","annidatedContent":null,"id":4},"id":3},"id":2}],
+                |[{"#type":"com.strumenta.kolasu.serialization.Content","id":1},
+                |{"#type":"com.strumenta.kolasu.serialization.Content","annidatedContent":{"#type":"com.strumenta.kolasu.serialization.Content",
+                |"annidatedContent":{"#type":"com.strumenta.kolasu.serialization.Content","id":4},"id":3},"id":2}],
                 |"name":"Section1"},"otherSections":[]}
             """.trimMargin().replace("\n", ""),
             json,


### PR DESCRIPTION
I have an issue with serializing JSON with streaming for the RPG Parser. The issue is that when generating JSON with streaming there is essentially an alternative serialization process that is not affected by custom serializers and works a bit differently. This tentative fix effectively uses for the serialization with streaming the same methods for normal serialization.

I have also ensured that it is always used the `gsonBuilder` with the custom serializers.

However, I do not know if there was a specific reason for using alternative serialization methods for streaming serialization. Maybe I am missing something.