### PR TITLE
PrinterOutput: don't wrap exceptions

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
@@ -121,11 +121,7 @@ class PrinterOutput(
         print(prefix)
         val printer = getPrinter(ast)
         associate(ast) {
-            try {
-                printer.print(this, ast)
-            } catch (e: Throwable) {
-                throw RuntimeException("Issue occurred while printing $ast", e)
-            }
+            printer.print(this, ast)
         }
         print(postfix)
     }


### PR DESCRIPTION
This fixes https://github.com/Strumenta/kolasu/issues/267 