### PR TITLE
Fix AST classes generation from lionweb language.

### DIFF
--- a/lionweb-gen/src/main/kotlin/com/strumenta/kolasu/lionweb/ASTGenerator.kt
+++ b/lionweb-gen/src/main/kotlin/com/strumenta/kolasu/lionweb/ASTGenerator.kt
@@ -66,8 +66,16 @@ class ASTGenerator(val packageName: String, val language: LWLanguage) {
                                 typeSpec.modifiers.add(KModifier.DATA)
                             }
                         }
+                        if(element.allFeatures().isEmpty() && !element.isAbstract) {
+                            val hasSubclasses = language.elements.filterIsInstance<Concept>().any {
+                                it.extendedConcept == element
+                            }
+                            if(hasSubclasses) {
+                                typeSpec.modifiers.add(KModifier.OPEN)
+                            }
+                        }
                         if (element.extendedConcept == null) {
-                            throw IllegalStateException()
+                            typeSpec.superclass(ClassName.bestGuess(Node::class.qualifiedName!!))
                         } else {
                             typeSpec.superclass(typeName(element.extendedConcept!!))
                             (element.extendedConcept as Concept).allFeatures().forEach {
@@ -212,7 +220,7 @@ class ASTGenerator(val packageName: String, val language: LWLanguage) {
                 Named::class.java.asTypeName()
             }
             classifier.language == this.language -> {
-                ClassName.bestGuess("$packageName.${classifier.name}")
+                ClassName(packageName, classifier.name!!)
             }
             else -> {
                 TODO("Classifier $classifier. ID ${classifier.id}, NODE id: ${LionCoreBuiltins.getNode().id}")


### PR DESCRIPTION
AST generation changes that check whether a class should be open and also fixes a bug when trying to refer to other generated class.