### PR TITLE
Improving parsing issues reporting

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Position.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Position.kt
@@ -143,6 +143,9 @@ data class SyntheticSource(val description: String) : Source()
  */
 data class Position(val start: Point, val end: Point, var source: Source? = null) : Comparable<Position>, Serializable {
 
+    val isFlat: Boolean
+        get() = start == end
+
     override fun toString(): String {
         return "Position(start=$start, end=$end${if (source == null) "" else ", source=$source"})"
     }

--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
@@ -246,11 +246,16 @@ fun Parser.injectErrorCollectorInParser(issues: MutableList<Issue>) {
             errorMessage: String?,
             p5: RecognitionException?
         ) {
+            val startPoint = Point(line, charPositionInLine)
+            var endPoint = startPoint
+            if (p1 is CommonToken) {
+                endPoint = startPoint.plus(p1.text)
+            }
             issues.add(
                 Issue(
                     IssueType.SYNTACTIC,
                     errorMessage?.capitalize() ?: "unspecified",
-                    position = Point(line, charPositionInLine).asPosition
+                    position = Position(startPoint, endPoint)
                 )
             )
         }

--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
@@ -3,6 +3,7 @@ package com.strumenta.kolasu.parsing
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Point
 import com.strumenta.kolasu.model.Position
+import com.strumenta.kolasu.utils.capitalize
 import com.strumenta.kolasu.validation.Issue
 import com.strumenta.kolasu.validation.IssueSeverity
 import com.strumenta.kolasu.validation.IssueType
@@ -248,7 +249,7 @@ fun Parser.injectErrorCollectorInParser(issues: MutableList<Issue>) {
             issues.add(
                 Issue(
                     IssueType.SYNTACTIC,
-                    errorMessage ?: "unspecified",
+                    errorMessage?.capitalize() ?: "unspecified",
                     position = Point(line, charPositionInLine).asPosition
                 )
             )

--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
@@ -217,12 +217,12 @@ fun Lexer.injectErrorCollectorInLexer(issues: MutableList<Issue>) {
     this.removeErrorListeners()
     this.addErrorListener(object : BaseErrorListener() {
         override fun syntaxError(
-            p0: Recognizer<*, *>?,
-            p1: Any?,
+            recognizer: Recognizer<*, *>?,
+            offendingSymbol: Any?,
             line: Int,
             charPositionInLine: Int,
             errorMessage: String?,
-            p5: RecognitionException?
+            recognitionException: RecognitionException?
         ) {
             issues.add(
                 Issue(
@@ -239,17 +239,17 @@ fun Parser.injectErrorCollectorInParser(issues: MutableList<Issue>) {
     this.removeErrorListeners()
     this.addErrorListener(object : BaseErrorListener() {
         override fun syntaxError(
-            p0: Recognizer<*, *>?,
-            p1: Any?,
+            recognizer: Recognizer<*, *>?,
+            offendingSymbol: Any?,
             line: Int,
             charPositionInLine: Int,
             errorMessage: String?,
-            p5: RecognitionException?
+            recognitionException: RecognitionException?
         ) {
             val startPoint = Point(line, charPositionInLine)
             var endPoint = startPoint
-            if (p1 is CommonToken) {
-                endPoint = startPoint.plus(p1.text)
+            if (offendingSymbol is CommonToken) {
+                endPoint = startPoint.plus(offendingSymbol.text)
             }
             issues.add(
                 Issue(

--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/Parsing.kt
@@ -249,7 +249,7 @@ fun Parser.injectErrorCollectorInParser(issues: MutableList<Issue>) {
             val startPoint = Point(line, charPositionInLine)
             var endPoint = startPoint
             if (offendingSymbol is CommonToken) {
-                endPoint = startPoint.plus(offendingSymbol.text)
+                endPoint = offendingSymbol.endPoint
             }
             issues.add(
                 Issue(

--- a/core/src/main/kotlin/com/strumenta/kolasu/utils/Text.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/utils/Text.kt
@@ -1,0 +1,3 @@
+package com.strumenta.kolasu.utils
+
+fun String.capitalize() = if (this.isBlank()) this else this.replaceFirstChar { it.uppercase()}

--- a/core/src/main/kotlin/com/strumenta/kolasu/utils/Text.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/utils/Text.kt
@@ -1,3 +1,3 @@
 package com.strumenta.kolasu.utils
 
-fun String.capitalize() = if (this.isBlank()) this else this.replaceFirstChar { it.uppercase()}
+fun String.capitalize() = if (this.isBlank()) this else this.replaceFirstChar { it.uppercase() }

--- a/core/src/test/kotlin/com/strumenta/kolasu/parsing/KolasuParserTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/parsing/KolasuParserTest.kt
@@ -88,4 +88,16 @@ class KolasuParserTest {
         assertNotNull(result.issues.find { it.message.startsWith("Extraneous input 'set'") })
         assertNotNull(result.issues.find { it.message.startsWith("Mismatched input 'c'") })
     }
+
+    @Test
+    fun issuesHaveNotFlatPosition() {
+        val parser = SimpleLangKolasuParser()
+        val result = parser.parse(
+            """set set a = 10
+            |display c
+            """.trimMargin()
+        )
+        assert(result.issues.isNotEmpty())
+        assert(result.issues.none { it.position?.isFlat ?: false })
+    }
 }

--- a/core/src/test/kotlin/com/strumenta/kolasu/parsing/KolasuParserTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/parsing/KolasuParserTest.kt
@@ -75,4 +75,17 @@ class KolasuParserTest {
         )
         assertEquals(1, parser.cachesCounter)
     }
+
+    @Test
+    fun issuesAreCapitalized() {
+        val parser = SimpleLangKolasuParser()
+        val result = parser.parse(
+            """set set a = 10
+            |display c
+            """.trimMargin()
+        )
+        assert(result.issues.isNotEmpty())
+        assertNotNull(result.issues.find { it.message.startsWith("Extraneous input 'set'") })
+        assertNotNull(result.issues.find { it.message.startsWith("Mismatched input 'c'") })
+    }
 }

--- a/core/src/test/kotlin/com/strumenta/kolasu/parsing/KolasuParserTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/parsing/KolasuParserTest.kt
@@ -1,6 +1,8 @@
 package com.strumenta.kolasu.parsing
 
 import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.Point
+import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.model.Source
 import com.strumenta.kolasu.validation.Issue
 import com.strumenta.simplelang.SimpleLangLexer
@@ -99,5 +101,9 @@ class KolasuParserTest {
         )
         assert(result.issues.isNotEmpty())
         assert(result.issues.none { it.position?.isFlat ?: false })
+        val extraneousInput = result.issues.find { it.message.startsWith("Extraneous input 'set'") }!!
+        assertEquals(Position(Point(1, 4), Point(1, 7)), extraneousInput.position)
+        val mismatchedInput = result.issues.find { it.message.startsWith("Mismatched input 'c'") }!!
+        assertEquals(Position(Point(2, 8), Point(2, 9)), mismatchedInput.position)
     }
 }


### PR DESCRIPTION
We do two things:
* We capitalize issues
* For issues that specify an issue on a token we specify the position for the issue to cover the whole token and not just the starting point of the token. Right now we specify "flat positions" (start == end), which means we cannot show those positions in editors