### PR TITLE
Add parameter to the Ecore exporter

### DIFF
--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
@@ -36,8 +36,18 @@ private val KClass<*>.packageName: String?
 
 /**
  * When building multiple related EPackages use MetamodelsBuilder instead.
+ *
+ * @param metamodelName this is the name of the metamodel, or the name assigned to the EPackage to be created
+ * @param kotlinPackageName this is where we look for Kotlin classes. By default it coincides with the metamodel name
+ *                          but in certain cases it may be different (for example having a suffix like model or ast)
  */
-class MetamodelBuilder(packageName: String, nsURI: String, nsPrefix: String, resource: Resource? = null) :
+class MetamodelBuilder(
+    metamodelName: String,
+    nsURI: String,
+    nsPrefix: String,
+    resource: Resource? = null,
+    val kotlinPackageName: String = metamodelName
+) :
     ClassifiersProvider {
 
     private val ePackage: EPackage = EcoreFactory.eINSTANCE.createEPackage()
@@ -48,7 +58,7 @@ class MetamodelBuilder(packageName: String, nsURI: String, nsPrefix: String, res
     internal var container: MetamodelsBuilder? = null
 
     init {
-        ePackage.name = packageName
+        ePackage.name = metamodelName
         ePackage.nsURI = nsURI
         ePackage.nsPrefix = nsPrefix
         if (resource == null) {
@@ -151,7 +161,7 @@ class MetamodelBuilder(packageName: String, nsURI: String, nsPrefix: String, res
             return EcoreFactory.eINSTANCE.ecorePackage.eObject
         }
 
-        if (kClass.packageName != this.ePackage.name) {
+        if (kClass.packageName != kotlinPackageName) {
             if (container != null) {
                 for (sibling in container!!.singleMetamodelsBuilders) {
                     if (sibling.canProvideClass(kClass)) {
@@ -342,14 +352,14 @@ class MetamodelBuilder(packageName: String, nsURI: String, nsPrefix: String, res
             return true
         }
 
-        return kClass.packageName == this.ePackage.name
+        return kClass.packageName == this.kotlinPackageName
     }
 
     override fun provideClass(kClass: KClass<*>): EClass {
         if (!eClasses.containsKey(kClass)) {
             val ch = eclassTypeHandlers.find { it.canHandle(kClass) }
             val eClass = ch?.toEClass(kClass, this) ?: classToEClass(kClass)
-            if (kClass.packageName != this.ePackage.name) {
+            if (kClass.packageName != this.kotlinPackageName) {
                 return eClass
             }
             if (ch == null || !ch.external()) {

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
@@ -171,7 +171,7 @@ class MetamodelBuilder(
             }
             throw Error(
                 "This class does not belong to this EPackage: ${kClass.qualifiedName}. " +
-                    "This EPackage: ${this.ePackage.name}"
+                    "This EPackage: ${this.ePackage.name}. Kotlin Package Name: $kotlinPackageName"
             )
         }
 

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilding.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilding.kt
@@ -61,8 +61,11 @@ fun EPackage.setResourceURI(uri: String) {
     resource.contents.add(this)
 }
 
-fun KolasuLanguage.toEPackage(nsUri: String? = null, nsPrefix: String? = null,
-                              kotlinPackageName: String = this.qualifiedName): EPackage {
+fun KolasuLanguage.toEPackage(
+    nsUri: String? = null,
+    nsPrefix: String? = null,
+    kotlinPackageName: String = this.qualifiedName
+): EPackage {
     val qualifiedNameParts = this.qualifiedName.split(".")
     val nsUriCalc = nsUri ?: if (qualifiedNameParts.size >= 3) {
         "https://${qualifiedNameParts[1]}.${qualifiedNameParts[0]}/" +

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilding.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilding.kt
@@ -61,7 +61,8 @@ fun EPackage.setResourceURI(uri: String) {
     resource.contents.add(this)
 }
 
-fun KolasuLanguage.toEPackage(nsUri: String? = null, nsPrefix: String? = null): EPackage {
+fun KolasuLanguage.toEPackage(nsUri: String? = null, nsPrefix: String? = null,
+                              kotlinPackageName: String = this.qualifiedName): EPackage {
     val qualifiedNameParts = this.qualifiedName.split(".")
     val nsUriCalc = nsUri ?: if (qualifiedNameParts.size >= 3) {
         "https://${qualifiedNameParts[1]}.${qualifiedNameParts[0]}/" +
@@ -73,7 +74,8 @@ fun KolasuLanguage.toEPackage(nsUri: String? = null, nsPrefix: String? = null): 
     val mmBuilder = MetamodelBuilder(
         this.qualifiedName,
         nsUriCalc,
-        nsPrefix ?: this.simpleName
+        nsPrefix ?: this.simpleName,
+        kotlinPackageName = kotlinPackageName
     )
     this.astClasses.forEach {
         mmBuilder.provideClass(it)

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/cli/KolasuLanguageGeneratorCommand.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/cli/KolasuLanguageGeneratorCommand.kt
@@ -7,10 +7,11 @@ import com.strumenta.kolasu.emf.saveAsJson
 import com.strumenta.kolasu.emf.toEPackage
 import com.strumenta.kolasu.language.KolasuLanguage
 
-class KolasuLanguageGeneratorCommand(val language: KolasuLanguage) : CliktCommand() {
+class KolasuLanguageGeneratorCommand(val language: KolasuLanguage,
+                                     private val kotlinPackageName: String = language.qualifiedName) : CliktCommand() {
     val languageFile by argument().file(canBeDir = false)
 
     override fun run() {
-        language.toEPackage().saveAsJson(languageFile)
+        language.toEPackage(kotlinPackageName=kotlinPackageName).saveAsJson(languageFile)
     }
 }

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/cli/KolasuLanguageGeneratorCommand.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/cli/KolasuLanguageGeneratorCommand.kt
@@ -7,11 +7,13 @@ import com.strumenta.kolasu.emf.saveAsJson
 import com.strumenta.kolasu.emf.toEPackage
 import com.strumenta.kolasu.language.KolasuLanguage
 
-class KolasuLanguageGeneratorCommand(val language: KolasuLanguage,
-                                     private val kotlinPackageName: String = language.qualifiedName) : CliktCommand() {
+class KolasuLanguageGeneratorCommand(
+    val language: KolasuLanguage,
+    private val kotlinPackageName: String = language.qualifiedName
+) : CliktCommand() {
     val languageFile by argument().file(canBeDir = false)
 
     override fun run() {
-        language.toEPackage(kotlinPackageName=kotlinPackageName).saveAsJson(languageFile)
+        language.toEPackage(kotlinPackageName = kotlinPackageName).saveAsJson(languageFile)
     }
 }


### PR DESCRIPTION
Fix #294
When exporting a Kolasu metamodel to Ecore permits to diffreentiate between the EPackage name and the package containing the Kotlin classes