### PR TITLE
Fixes to support RPG Parser and LionWeb

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/language/KolasuLanguage.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/language/KolasuLanguage.kt
@@ -65,6 +65,9 @@ class KolasuLanguage(val qualifiedName: String) {
     }
 
     fun <N : Node> addClass(kClass: KClass<N>): Boolean {
+        if (kClass == Node::class) {
+            return false
+        }
         if (!_astClasses.contains(kClass) && _astClasses.add(kClass)) {
             kClass.supertypes.forEach { superType ->
                 processSuperType(superType)

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
@@ -215,7 +215,6 @@ val <T : Any> Class<T>.nodeProperties: Collection<KProperty1<T, *>>
 val <T : Any> KClass<T>.nodeProperties: Collection<KProperty1<T, *>>
     get() = memberProperties.asSequence()
         .filter { it.visibility == KVisibility.PUBLIC }
-        .filter { it.findAnnotation<Derived>() == null }
         .filter { it.findAnnotation<Internal>() == null }
         .filter { it.findAnnotation<Link>() == null }
         .toList()

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Reflection.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Reflection.kt
@@ -9,6 +9,7 @@ import kotlin.reflect.KClassifier
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
+import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.withNullability
 
@@ -51,7 +52,8 @@ data class PropertyDescription(
     val provideNodes: Boolean,
     val multiplicity: Multiplicity,
     val value: Any?,
-    val propertyType: PropertyType
+    val propertyType: PropertyType,
+    val derived: Boolean
 ) {
 
     fun valueToString(): String {
@@ -119,7 +121,8 @@ data class PropertyDescription(
                     property.isReference() -> PropertyType.REFERENCE
                     provideNodes -> PropertyType.CONTAINMENT
                     else -> PropertyType.ATTRIBUTE
-                }
+                },
+                derived = property.findAnnotation<Derived>() != null
             )
         }
     }

--- a/core/src/test/kotlin/com/strumenta/kolasu/model/PropertyDescriptionTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/model/PropertyDescriptionTest.kt
@@ -25,7 +25,8 @@ class PropertyDescriptionTest {
                 false,
                 Multiplicity.SINGULAR,
                 "gino",
-                PropertyType.ATTRIBUTE
+                PropertyType.ATTRIBUTE,
+                derived = false
             ),
             list[0]
         )
@@ -45,7 +46,8 @@ class PropertyDescriptionTest {
                 false,
                 Multiplicity.MANY,
                 listOf("gino", "pino"),
-                PropertyType.ATTRIBUTE
+                PropertyType.ATTRIBUTE,
+                derived = false
             ),
             list[0]
         )
@@ -65,7 +67,8 @@ class PropertyDescriptionTest {
                 true,
                 Multiplicity.SINGULAR,
                 Foo1("gino"),
-                PropertyType.CONTAINMENT
+                PropertyType.CONTAINMENT,
+                derived = false
             ),
             list[0]
         )
@@ -85,7 +88,8 @@ class PropertyDescriptionTest {
                 true,
                 Multiplicity.MANY,
                 listOf(Foo1("gino")),
-                PropertyType.CONTAINMENT
+                PropertyType.CONTAINMENT,
+                derived = false
             ),
             list[0]
         )
@@ -105,7 +109,8 @@ class PropertyDescriptionTest {
                 true,
                 Multiplicity.MANY,
                 emptyList<Foo1>(),
-                PropertyType.CONTAINMENT
+                PropertyType.CONTAINMENT,
+                derived = false
             ),
             list[0]
         )
@@ -125,7 +130,8 @@ class PropertyDescriptionTest {
                 true,
                 Multiplicity.MANY,
                 null,
-                PropertyType.CONTAINMENT
+                PropertyType.CONTAINMENT,
+                derived = false
             ),
             list[0]
         )

--- a/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonGenerationTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/serialization/JsonGenerationTest.kt
@@ -338,28 +338,32 @@ class JsonGenerationTest {
                     false,
                     Multiplicity.SINGULAR,
                     123,
-                    PropertyType.ATTRIBUTE
+                    PropertyType.ATTRIBUTE,
+                    derived = false
                 ),
                 PropertyDescription(
                     "someListAttr",
                     false,
                     Multiplicity.MANY,
                     listOf("a", "b"),
-                    PropertyType.ATTRIBUTE
+                    PropertyType.ATTRIBUTE,
+                    derived = false
                 ),
                 PropertyDescription(
                     "someChild",
                     true,
                     Multiplicity.SINGULAR,
                     BaseNode(456),
-                    PropertyType.CONTAINMENT
+                    PropertyType.CONTAINMENT,
+                    derived = false
                 ),
                 PropertyDescription(
                     "someChildren",
                     true,
                     Multiplicity.MANY,
                     listOf(BaseNode(78), BaseNode(90)),
-                    PropertyType.CONTAINMENT
+                    PropertyType.CONTAINMENT,
+                    derived = false
                 )
             )
         )

--- a/javalib/src/test/java/com/strumenta/kolasu/javalib/CompilationUnit.java
+++ b/javalib/src/test/java/com/strumenta/kolasu/javalib/CompilationUnit.java
@@ -20,7 +20,7 @@ public class CompilationUnit extends Node {
         @Override
         @Internal
         public List<PropertyDescription> getProperties() {
-            return Arrays.asList(new PropertyDescription("bs", true, Multiplicity.MANY, getBs(), PropertyType.CONTAINMENT));
+            return Arrays.asList(new PropertyDescription("bs", true, Multiplicity.MANY, getBs(), PropertyType.CONTAINMENT, false));
         }
     }
 
@@ -38,6 +38,6 @@ public class CompilationUnit extends Node {
     @Override
     @Internal
     public List<PropertyDescription> getProperties() {
-        return Arrays.asList(new PropertyDescription("as", true, Multiplicity.MANY, getAs(), PropertyType.CONTAINMENT));
+        return Arrays.asList(new PropertyDescription("as", true, Multiplicity.MANY, getAs(), PropertyType.CONTAINMENT, false));
     }
 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebLanguageConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebLanguageConverter.kt
@@ -17,6 +17,7 @@ import io.lionweb.lioncore.java.language.DataType
 import io.lionweb.lioncore.java.language.Enumeration
 import io.lionweb.lioncore.java.language.Interface
 import io.lionweb.lioncore.java.language.LionCoreBuiltins
+import io.lionweb.lioncore.java.language.PrimitiveType
 import io.lionweb.lioncore.java.language.Property
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -28,6 +29,7 @@ import kotlin.reflect.full.createType
 class LionWebLanguageConverter {
     private val astClassesAndClassifiers = BiMap<KClass<*>, Classifier<*>>()
     private val classesAndEnumerations = BiMap<EnumKClass, Enumeration>()
+    private val primitiveTypes = BiMap<KClass<*>, PrimitiveType>()
     private val languages = BiMap<KolasuLanguage, LWLanguage>()
 
     init {
@@ -233,7 +235,15 @@ class LionWebLanguageConverter {
                         return enumeration
                     }
                 } else {
-                    throw UnsupportedOperationException("KType: $kType")
+                    val primitiveType = primitiveTypes.byA(kClass)
+                    if (primitiveType == null) {
+                        val newPrimitiveType = PrimitiveType(lionwebLanguage, kClass.simpleName)
+                        lionwebLanguage.addElement(newPrimitiveType)
+                        primitiveTypes.associate(kClass, newPrimitiveType)
+                        return newPrimitiveType
+                    } else {
+                        return primitiveType
+                    }
                 }
             }
         }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebLanguageConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebLanguageConverter.kt
@@ -218,6 +218,7 @@ class LionWebLanguageConverter {
             Long::class.createType() -> LionCoreBuiltins.getInteger()
             String::class.createType() -> LionCoreBuiltins.getString()
             Boolean::class.createType() -> LionCoreBuiltins.getBoolean()
+            Char::class.createType() -> StarLasuLWLanguage.char
             else -> {
                 val kClass = kType.classifier as KClass<*>
                 val isEnum = kClass.supertypes.any { it.classifier == Enum::class }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
@@ -2,6 +2,7 @@ package com.strumenta.kolasu.lionweb
 
 import io.lionweb.lioncore.java.language.Concept
 import io.lionweb.lioncore.java.language.Language
+import io.lionweb.lioncore.java.language.PrimitiveType
 
 object StarLasuLWLanguage : Language() {
     init {
@@ -10,8 +11,12 @@ object StarLasuLWLanguage : Language() {
         version = "1"
         key = id
         Concept(this, "ASTNode", id + "_ASTNode").setKey(id + "_ASTNode")
+        PrimitiveType(this, "Char", id + "_Char").setKey(id + "_Char")
     }
 
     val ASTNode: Concept
         get() = getConceptByName("ASTNode")!!
+
+    val char: PrimitiveType
+        get() = getPrimitiveTypeByName("Char")!!
 }


### PR DESCRIPTION
* We add support for the Char type when converting to LionWeb
* When converting to LionWeb, we treat each type which is not a descendant of Node as a new Primitive type (note that it will require serializers and deserializers when converting ASTs to or from LionWeb)
* We support also derived properties as there was a case when `name` was marked as derived and it ended up being ignored