### PR TITLE
Avoid conflict in lion web conversion

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -248,7 +248,7 @@ fun Node.indexInContainingProperty(): Int? {
     return if (p == null) {
         null
     } else if (p.value is Collection<*>) {
-        p.value.indexOf(this)
+        p.value.indexOfFirst { this === it}
     } else {
         0
     }

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -231,9 +231,9 @@ fun Node.containingProperty(): PropertyDescription? {
     }
     return this.parent!!.properties.find { p ->
         val v = p.value
-        when (v) {
-            is Collection<*> -> v.contains(this)
-            this -> true
+        when {
+            v is Collection<*> -> v.any { it === this }
+            v === this -> true
             else -> false
         }
     } ?: throw IllegalStateException("No containing property for $this with parent ${this.parent}")
@@ -248,7 +248,7 @@ fun Node.indexInContainingProperty(): Int? {
     return if (p == null) {
         null
     } else if (p.value is Collection<*>) {
-        p.value.indexOfFirst { this === it}
+        p.value.indexOfFirst { this === it }
     } else {
         0
     }

--- a/core/src/test/kotlin/com/strumenta/kolasu/model/ProcessingTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/model/ProcessingTest.kt
@@ -282,4 +282,19 @@ class ProcessingTest {
         assertEquals(1, a3.indexInContainingProperty())
         assertEquals(2, a4.indexInContainingProperty())
     }
+
+    @test
+    fun indexInContainingPropertyWhenNodeAreEquals() {
+        val a1 = AW("1")
+        val a2 = AW("2")
+        val a3 = AW("3")
+        val a4 = AW("2")
+        val b = BW(a1, mutableListOf(a2, a3, a4))
+        b.assignParents()
+        assertEquals(null, b.indexInContainingProperty())
+        assertEquals(0, a1.indexInContainingProperty())
+        assertEquals(0, a2.indexInContainingProperty())
+        assertEquals(1, a3.indexInContainingProperty())
+        assertEquals(2, a4.indexInContainingProperty())
+    }
 }

--- a/core/src/test/kotlin/com/strumenta/kolasu/model/ProcessingTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/model/ProcessingTest.kt
@@ -269,6 +269,21 @@ class ProcessingTest {
     }
 
     @test
+    fun containingPropertyWhenNodesAreEquals() {
+        val a1 = AW("1")
+        val a2 = AW("1")
+        val a3 = AW("1")
+        val a4 = AW("4")
+        val b = BW(a1, mutableListOf(a2, a3, a4))
+        b.assignParents()
+        assertEquals(null, b.containingProperty())
+        assertEquals("a", a1.containingProperty()?.name)
+        assertEquals("manyAs", a2.containingProperty()?.name)
+        assertEquals("manyAs", a3.containingProperty()?.name)
+        assertEquals("manyAs", a4.containingProperty()?.name)
+    }
+
+    @test
     fun indexInContainingProperty() {
         val a1 = AW("1")
         val a2 = AW("2")

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,6 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 jvm_version=1.8
 junit_version=4.13.2
 gson_version=2.10.1
-lionwebVersion=0.2.3
+lionwebVersion=0.2.5
 kspVersion=1.0.11
 lionwebGenGradlePluginID=com.strumenta.kolasu.lionwebgen

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/BiMap.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/BiMap.kt
@@ -1,6 +1,8 @@
 package com.strumenta.kolasu.lionweb
 
-class BiMap<A, B> {
+import java.util.IdentityHashMap
+
+class BiMap<A, B>(val usingIdentity: Boolean = false) {
     val `as`: Set<A>
         get() = _asToBs.keys
     val bs: Set<B>
@@ -10,8 +12,8 @@ class BiMap<A, B> {
     val bsToAsMap: Map<B, A>
         get() = _bsToAs
 
-    private val _asToBs = mutableMapOf<A, B>()
-    private val _bsToAs = mutableMapOf<B, A>()
+    private val _asToBs = if (usingIdentity) IdentityHashMap() else mutableMapOf<A, B>()
+    private val _bsToAs = if (usingIdentity) IdentityHashMap() else mutableMapOf<B, A>()
 
     fun associate(a: A, b: B) {
         _asToBs[a] = b

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -35,7 +35,7 @@ import kotlin.reflect.full.primaryConstructor
  */
 class LionWebModelConverter {
     private val languageConverter = LionWebLanguageConverter()
-    private val nodesMapping = BiMap<KNode, LWNode>()
+    private val nodesMapping = BiMap<KNode, LWNode>(usingIdentity = true)
 
     fun correspondingLanguage(kolasuLanguage: KolasuLanguage): Language {
         return languageConverter.correspondingLanguage(kolasuLanguage)


### PR DESCRIPTION
Nodes which are "equals" but are not the same identity, cause issues when converting to LionWeb.