### PR TITLE
Introducing the LionWebNodeIdProvider

### DIFF
--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -184,11 +184,8 @@ class LionWebModelConverter {
                             val entries = kClass.java.methods.find {
                                 it.name == "getEntries"
                             }!!.invoke(null) as List<Any>
-                            // val entriesProp = kClass.memberProperties.find { it.name == "entries" }
-                            // val fields = kClass.java.declaredFields.filter { Modifier.isStatic(it.modifiers) }.map { it.get(null) }
                             val nameProp = kClass.memberProperties.find { it.name == "name" }!! as KProperty1<Any, *>
                             val namesToFields = entries.associate { nameProp.invoke(it) as String to it }
-                            // val entries = kClass.staticProperties.first().get()
                             val nameToSearch = propValue.serializedValue.split("/").last()
                             params[param] = namesToFields[nameToSearch]!!
                         } else {

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -1,13 +1,9 @@
 package com.strumenta.kolasu.lionweb
 
 import com.strumenta.kolasu.language.KolasuLanguage
-import com.strumenta.kolasu.model.FileSource
 import com.strumenta.kolasu.model.PossiblyNamed
 import com.strumenta.kolasu.model.ReferenceByName
-import com.strumenta.kolasu.model.Source
 import com.strumenta.kolasu.model.allFeatures
-import com.strumenta.kolasu.model.containingProperty
-import com.strumenta.kolasu.model.indexInContainingProperty
 import com.strumenta.kolasu.traversing.walk
 import io.lionweb.lioncore.java.language.Concept
 import io.lionweb.lioncore.java.language.Containment
@@ -31,8 +27,10 @@ import kotlin.reflect.full.primaryConstructor
 
 /**
  * This class is able to convert between Kolasu and LionWeb models, tracking the mapping.
+ *
+ * @param nodeIdProvider logic to be used to associate IDs to Kolasu nodes when exporting them to LionWeb
  */
-class LionWebModelConverter {
+class LionWebModelConverter(var nodeIdProvider: LionWebNodeIdProvider = StructuralLionWebNodeIdProvider()) {
     private val languageConverter = LionWebLanguageConverter()
     private val nodesMapping = BiMap<KNode, LWNode>(usingIdentity = true)
 
@@ -48,13 +46,13 @@ class LionWebModelConverter {
         this.languageConverter.associateLanguages(lwLanguage, kolasuLanguage)
     }
 
-    fun exportModelToLionWeb(kolasuTree: KNode, customSourceId: String? = null): LWNode {
+    fun exportModelToLionWeb(kolasuTree: KNode): LWNode {
         if (nodesMapping.containsA(kolasuTree)) {
             return nodesMapping.byA(kolasuTree)!!
         }
         kolasuTree.walk().forEach { kNode ->
             if (!nodesMapping.containsA(kNode)) {
-                val lwNode = DynamicNode(nodeID(kNode, customSourceId), findConcept(kNode))
+                val lwNode = DynamicNode(nodeIdProvider.id(kNode), findConcept(kNode))
                 associateNodes(kNode, lwNode)
             }
         }
@@ -256,33 +254,7 @@ class LionWebModelConverter {
         return languageConverter.correspondingConcept(kNode.javaClass.kotlin)
     }
 
-    private fun nodeID(kNode: com.strumenta.kolasu.model.Node, customSourceId: String? = null): String {
-        return "${customSourceId ?: kNode.source.id}_${kNode.positionalID}"
-    }
-
     private fun associateNodes(kNode: KNode, lwNode: LWNode) {
         nodesMapping.associate(kNode, lwNode)
     }
 }
-
-private val KNode.positionalID: String
-    get() {
-        return if (this.parent == null) {
-            "root"
-        } else {
-            val cp = this.containingProperty()!!
-            val postfix = if (cp.multiple) "${cp.name}_${this.indexInContainingProperty()!!}" else cp.name
-            "${this.parent!!.positionalID}_$postfix"
-        }
-    }
-
-private val Source?.id: String
-    get() {
-        return if (this == null) {
-            "UNKNOWN_SOURCE"
-        } else if (this is FileSource) {
-            "file_${this.file.path.replace('.', '-').replace('/', '-')}"
-        } else {
-            TODO("Unable to generate ID for Source $this (${this.javaClass.canonicalName})")
-        }
-    }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebNodeIdProvider.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebNodeIdProvider.kt
@@ -1,0 +1,15 @@
+package com.strumenta.kolasu.lionweb
+
+import com.strumenta.kolasu.model.Node as KNode
+
+/**
+ * This defines a policy to associate IDs to Kolasu Nodes.
+ * This is necessary as Kolasu Nodes have no IDs, but LionWeb Nodes need IDs.
+ * It is important that the logic is implemented so that given the same Node, the same ID is returned.
+ */
+interface LionWebNodeIdProvider {
+    /**
+     * @return a valid LionWeb Node ID
+     */
+    fun id(kNode: KNode): String
+}

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/SourceIdProvider.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/SourceIdProvider.kt
@@ -1,0 +1,54 @@
+package com.strumenta.kolasu.lionweb
+
+import com.strumenta.kolasu.model.FileSource
+import com.strumenta.kolasu.model.Source
+import java.io.File
+
+/**
+ * Given a Source (even null), it generates a corresponding identifier.
+ */
+interface SourceIdProvider {
+    fun sourceId(source: Source?): String
+}
+
+abstract class AbstractSourceIdProvider : SourceIdProvider {
+    protected fun cleanId(id: String) = id.replace('.', '-').replace('/', '-')
+}
+
+class SimpleSourceIdProvider : AbstractSourceIdProvider() {
+    override fun sourceId(source: Source?): String {
+        return when (source) {
+            null -> {
+                "UNKNOWN_SOURCE"
+            }
+            is FileSource -> {
+                cleanId("file_${source.file.path}")
+            }
+            else -> {
+                TODO("Unable to generate ID for Source $this (${this.javaClass.canonicalName})")
+            }
+        }
+    }
+}
+
+class RelativeSourceIdProvider(val baseDir: File, var rootName: String? = null) : AbstractSourceIdProvider() {
+    override fun sourceId(source: Source?): String {
+        return when (source) {
+            null -> {
+                "UNKNOWN_SOURCE"
+            }
+            is FileSource -> {
+                val thisAbsPath = source.file.absolutePath
+                val baseAbsPath = baseDir.absolutePath
+                val expectedPrefix = baseAbsPath + File.separator
+                require(thisAbsPath.startsWith(expectedPrefix))
+                val relativePath = thisAbsPath.removePrefix(expectedPrefix)
+                val id = if (rootName == null) relativePath else "${rootName}___$relativePath"
+                return cleanId(id)
+            }
+            else -> {
+                TODO("Unable to generate ID for Source $this (${this.javaClass.canonicalName})")
+            }
+        }
+    }
+}

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProvider.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProvider.kt
@@ -10,7 +10,8 @@ class ConstantSourceIdProvider(var value: String) : SourceIdProvider {
     override fun sourceId(source: Source?) = value
 }
 
-class StructuralLionWebNodeIdProvider(var sourceIdProvider: SourceIdProvider = SimpleSourceIdProvider()) : LionWebNodeIdProvider {
+class StructuralLionWebNodeIdProvider(var sourceIdProvider: SourceIdProvider = SimpleSourceIdProvider()) :
+    LionWebNodeIdProvider {
 
     constructor(customSourceId: String) : this(ConstantSourceIdProvider(customSourceId))
 

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProvider.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProvider.kt
@@ -1,0 +1,35 @@
+package com.strumenta.kolasu.lionweb
+
+import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.Source
+import com.strumenta.kolasu.model.containingProperty
+import com.strumenta.kolasu.model.indexInContainingProperty
+import io.lionweb.lioncore.java.utils.CommonChecks
+
+class ConstantSourceIdProvider(var value: String) : SourceIdProvider {
+    override fun sourceId(source: Source?) = value
+}
+
+class StructuralLionWebNodeIdProvider(var sourceIdProvider: SourceIdProvider = SimpleSourceIdProvider()) : LionWebNodeIdProvider {
+
+    constructor(customSourceId: String) : this(ConstantSourceIdProvider(customSourceId))
+
+    override fun id(kNode: Node): String {
+        val id = "${sourceIdProvider.sourceId(kNode.source)}_${kNode.positionalID}"
+        if (!CommonChecks.isValidID(id)) {
+            throw IllegalStateException("An invalid LionWeb Node ID has been produced")
+        }
+        return id
+    }
+
+    private val KNode.positionalID: String
+        get() {
+            return if (this.parent == null) {
+                "root"
+            } else {
+                val cp = this.containingProperty()!!
+                val postfix = if (cp.multiple) "${cp.name}_${this.indexInContainingProperty()!!}" else cp.name
+                "${this.parent!!.positionalID}_$postfix"
+            }
+        }
+}

--- a/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProviderTest.kt
+++ b/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProviderTest.kt
@@ -39,7 +39,7 @@ class StructuralLionWebNodeIdProviderTest {
         root.walk().forEach { node ->
             val id = ip.id(node)
             assertNotNull(id)
-            assert(id !in encounteredIDs) { "Node ID ${id} was already used" }
+            assert(id !in encounteredIDs) { "Node ID $id was already used" }
             encounteredIDs.add(id)
         }
         assertEquals(7, encounteredIDs.size)

--- a/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProviderTest.kt
+++ b/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProviderTest.kt
@@ -1,0 +1,78 @@
+package com.strumenta.kolasu.lionweb
+
+import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.assignParents
+import com.strumenta.kolasu.traversing.walk
+import junit.framework.TestCase.assertNotNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+data class A(val bs: MutableList<B> = mutableListOf()) : Node()
+data class B(var name: String, var cs: MutableList<C> = mutableListOf()) : Node()
+data class C(var value: Int) : Node()
+
+class StructuralLionWebNodeIdProviderTest {
+
+    @Test
+    fun equalsNodesInTreeGetDifferentIDs() {
+        val root = A(
+            mutableListOf(
+                B(
+                    "foo",
+                    mutableListOf(
+                        C(1),
+                        C(2)
+                    )
+                ),
+                B(
+                    "foo",
+                    mutableListOf(
+                        C(1),
+                        C(2)
+                    )
+                )
+            )
+        )
+        root.assignParents()
+        val ip = StructuralLionWebNodeIdProvider()
+        val encounteredIDs = mutableSetOf<String>()
+        root.walk().forEach { node ->
+            val id = ip.id(node)
+            assertNotNull(id)
+            assert(id !in encounteredIDs) { "Node ID ${id} was already used" }
+            encounteredIDs.add(id)
+        }
+        assertEquals(7, encounteredIDs.size)
+    }
+
+    @Test
+    fun equalsNodesInNotInTreeGetDifferentIDs() {
+        val root = A(
+            mutableListOf(
+                B(
+                    "foo",
+                    mutableListOf(
+                        C(1),
+                        C(2)
+                    )
+                ),
+                B(
+                    "foo",
+                    mutableListOf(
+                        C(1),
+                        C(2)
+                    )
+                )
+            )
+        )
+        // we do NOT call assignParents
+        val ip = StructuralLionWebNodeIdProvider()
+        root.walk().forEach { node ->
+            val id = ip.id(node)
+            assertNotNull(id)
+        }
+        assertEquals(ip.id(root.bs[0]), ip.id(root.bs[1]))
+        assertEquals(ip.id(root.bs[0].cs[0]), ip.id(root.bs[1].cs[0]))
+        assertEquals(ip.id(root.bs[0].cs[1]), ip.id(root.bs[1].cs[1]))
+    }
+}


### PR DESCRIPTION
We introduce an interface defining the logic used to produce LionWeb Node IDs for Kolasu Nodes.
This logic could be used to "predict" which ID will be associated to each node. We will also be able to recalculate that ID, if we have access to the instance of the LionWebNodeIdProvider. 

This is relevant for the Code Insight Studio and for the symbol resolution.