### PR TITLE
ID Logic based on coordinates

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/ids/DeclarativeNodeIdProvider.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/ids/DeclarativeNodeIdProvider.kt
@@ -23,8 +23,7 @@ open class DeclarativeNodeIdProvider(
     vararg rules: DeclarativeNodeIdProviderRule<out Node>
 ) : NodeIdProvider {
     private val rules: List<DeclarativeNodeIdProviderRule<out Node>> = rules.sorted()
-
-    override fun id(kNode: Node): String {
+    override fun idUsingCoordinates(kNode: Node, coordinates: Coordinates): String {
         return this.rules.firstOrNull { it.canBeInvokedWith(kNode::class) }?.invoke(this, kNode)
             ?: throw RuntimeException("Cannot find rule for node type: ${kNode::class.qualifiedName}")
     }

--- a/core/src/main/kotlin/com/strumenta/kolasu/ids/NodeIdProvider.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/ids/NodeIdProvider.kt
@@ -1,5 +1,7 @@
 package com.strumenta.kolasu.ids
 
+import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.containingProperty
 import com.strumenta.kolasu.model.Node as KNode
 
 /**
@@ -9,11 +11,33 @@ import com.strumenta.kolasu.model.Node as KNode
  */
 interface NodeIdProvider {
     /**
+     * @param coordinates the coordinates at which the node is to be placed
      * @return a valid LionWeb Node ID
      */
-    fun id(kNode: KNode): String
+    fun idUsingCoordinates(kNode: KNode, coordinates: Coordinates): String
+
+    fun id(kNode: KNode, overriddenCoordinates: Coordinates? = null): String {
+        return idUsingCoordinates(kNode, overriddenCoordinates ?: calculatedCoordinates(kNode))
+    }
+
+    private fun calculatedCoordinates(kNode: Node): Coordinates {
+        return if (kNode.parent == null) {
+            RootCoordinates
+        } else {
+            NonRootCoordinates(this.id(kNode.parent!!), kNode.containingProperty()!!.name)
+        }
+    }
 }
 
 interface IDLogic {
-    val calculatedID: String
+    fun calculatedID(coordinates: Coordinates? = null): String
 }
+
+sealed class Coordinates
+
+object RootCoordinates : Coordinates()
+
+data class NonRootCoordinates(
+    val containerID: String,
+    val containmentName: String
+) : Coordinates()

--- a/core/src/main/kotlin/com/strumenta/kolasu/ids/NodeIdProvider.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/ids/NodeIdProvider.kt
@@ -30,7 +30,7 @@ interface NodeIdProvider {
 }
 
 interface IDLogic {
-    fun calculatedID(coordinates: Coordinates? = null): String
+    fun calculatedID(coordinates: Coordinates): String
 }
 
 sealed class Coordinates

--- a/core/src/main/kotlin/com/strumenta/kolasu/ids/SourceIdProvider.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/ids/SourceIdProvider.kt
@@ -25,7 +25,7 @@ abstract class AbstractSourceIdProvider : SourceIdProvider {
 class SimpleSourceIdProvider(var acceptNullSource: Boolean = false) : AbstractSourceIdProvider() {
     override fun sourceId(source: Source?): String {
         if (source is IDLogic) {
-            return source!!.calculatedID(null)
+            return source!!.calculatedID(RootCoordinates)
         }
         return when (source) {
             null -> {

--- a/core/src/main/kotlin/com/strumenta/kolasu/ids/StructuralNodeIdProvider.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/ids/StructuralNodeIdProvider.kt
@@ -2,7 +2,6 @@ package com.strumenta.kolasu.ids
 
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Source
-import com.strumenta.kolasu.model.containingProperty
 import com.strumenta.kolasu.model.indexInContainingProperty
 
 class ConstantSourceIdProvider(var value: String) : SourceIdProvider {
@@ -14,19 +13,25 @@ open class StructuralNodeIdProvider(var sourceIdProvider: SourceIdProvider = Sim
 
     constructor(customSourceId: String) : this(ConstantSourceIdProvider(customSourceId))
 
-    override fun id(kNode: Node): String {
-        val id = "${sourceIdProvider.sourceId(kNode.source)}_${kNode.positionalID}"
-        return id
-    }
-
-    private val Node.positionalID: String
-        get() {
-            return if (this.parent == null) {
-                "root"
-            } else {
-                val cp = this.containingProperty()!!
-                val postfix = if (cp.multiple) "${cp.name}_${this.indexInContainingProperty()!!}" else cp.name
-                "${this.parent!!.positionalID}_$postfix"
+    override fun idUsingCoordinates(kNode: Node, coordinates: Coordinates): String {
+        if (kNode is IDLogic) {
+            return kNode.calculatedID(coordinates)
+        }
+        when (coordinates) {
+            is RootCoordinates -> {
+                val sourceId = try {
+                    sourceIdProvider.sourceId(kNode.source)
+                } catch (e: IDGenerationException) {
+                    throw IDGenerationException("Cannot get source id for node $kNode", e)
+                }
+                return "${sourceId}_root"
+            }
+            is NonRootCoordinates -> {
+                // TODO consider getting index from Coordinates
+                val index = kNode.indexInContainingProperty()!!
+                val postfix = if (index == 0) coordinates.containmentName else "${coordinates.containmentName}_$index"
+                return "${coordinates.containerID!!}_$postfix"
             }
         }
+    }
 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebLanguageConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebLanguageConverter.kt
@@ -238,6 +238,10 @@ class LionWebLanguageConverter {
         return toLWClassifier(kClass) as Concept
     }
 
+    fun correspondingConcept(nodeType: String): Concept {
+        return toLWClassifier(nodeType) as Concept
+    }
+
     fun correspondingKolasuClass(classifier: Classifier<*>): KClass<*>? {
         return this.astClassesAndClassifiers.bsToAsMap.entries.find {
             it.key.key == classifier.key &&
@@ -252,6 +256,14 @@ class LionWebLanguageConverter {
 
     private fun toLWClassifier(kClass: KClass<*>): Classifier<*> {
         return astClassesAndClassifiers.byA(kClass) ?: throw IllegalArgumentException("Unknown KClass $kClass")
+    }
+
+    private fun toLWClassifier(nodeType: String): Classifier<*> {
+        val kClass = astClassesAndClassifiers.`as`.find { it.qualifiedName == nodeType }
+            ?: throw IllegalArgumentException(
+                "Unknown nodeType $nodeType"
+            )
+        return toLWClassifier(kClass)
     }
 
     private fun toLWEnumeration(kClass: KClass<*>, lionwebLanguage: LWLanguage): Enumeration {

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebRootSource.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebRootSource.kt
@@ -6,7 +6,7 @@ import com.strumenta.kolasu.model.Source
 
 data class LionWebRootSource(val sourceId: String) : Source(), IDLogic {
 
-    override fun calculatedID(coordinates: Coordinates?): String {
+    override fun calculatedID(coordinates: Coordinates): String {
         return sourceId
     }
 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebRootSource.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebRootSource.kt
@@ -1,9 +1,12 @@
 package com.strumenta.kolasu.lionweb
 
+import com.strumenta.kolasu.ids.Coordinates
 import com.strumenta.kolasu.ids.IDLogic
 import com.strumenta.kolasu.model.Source
 
 data class LionWebRootSource(val sourceId: String) : Source(), IDLogic {
-    override val calculatedID: String
-        get() = sourceId
+
+    override fun calculatedID(coordinates: Coordinates?): String {
+        return sourceId
+    }
 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProvider.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProvider.kt
@@ -1,6 +1,7 @@
 package com.strumenta.kolasu.lionweb
 
 import com.strumenta.kolasu.ids.ConstantSourceIdProvider
+import com.strumenta.kolasu.ids.Coordinates
 import com.strumenta.kolasu.ids.SimpleSourceIdProvider
 import com.strumenta.kolasu.ids.SourceIdProvider
 import com.strumenta.kolasu.ids.StructuralNodeIdProvider
@@ -12,8 +13,8 @@ class StructuralLionWebNodeIdProvider(sourceIdProvider: SourceIdProvider = Simpl
 
     constructor(customSourceId: String) : this(ConstantSourceIdProvider(customSourceId))
 
-    override fun id(kNode: Node): String {
-        val id = super.id(kNode)
+    override fun idUsingCoordinates(kNode: Node, coordinates: Coordinates): String {
+        val id = super.idUsingCoordinates(kNode, coordinates)
         if (!CommonChecks.isValidID(id)) {
             throw IllegalStateException("An invalid LionWeb Node ID has been produced")
         }

--- a/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverterTest.kt
+++ b/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverterTest.kt
@@ -4,6 +4,7 @@ import com.strumenta.kolasu.language.KolasuLanguage
 import com.strumenta.kolasu.model.Point
 import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.model.ReferenceByName
+import com.strumenta.kolasu.model.SyntheticSource
 import com.strumenta.kolasu.model.assignParents
 import com.strumenta.kolasu.model.withPosition
 import com.strumenta.kolasu.testing.assertASTsAreEqual
@@ -35,7 +36,7 @@ class LionWebModelConverterTest {
   ],
   "nodes": [
     {
-      "id": "UNKNOWN_SOURCE_root",
+      "id": "synthetic_foo-bar-source_root",
       "classifier": {
         "language": "com-strumenta-SimpleLang",
         "version": "1",
@@ -59,9 +60,9 @@ class LionWebModelConverterTest {
             "key": "com-strumenta-SimpleLang_SimpleRoot_childrez"
           },
           "children": [
-            "UNKNOWN_SOURCE_root_childrez_0",
-            "UNKNOWN_SOURCE_root_childrez_1",
-            "UNKNOWN_SOURCE_root_childrez_2"
+            "synthetic_foo-bar-source_root_childrez",
+            "synthetic_foo-bar-source_root_childrez_1",
+            "synthetic_foo-bar-source_root_childrez_2"
           ]
         },
         {
@@ -78,7 +79,7 @@ class LionWebModelConverterTest {
       "parent": null
     },
     {
-      "id": "UNKNOWN_SOURCE_root_childrez_0",
+      "id": "synthetic_foo-bar-source_root_childrez",
       "classifier": {
         "language": "com-strumenta-SimpleLang",
         "version": "1",
@@ -122,16 +123,16 @@ class LionWebModelConverterTest {
           "targets": [
             {
               "resolveInfo": "A1",
-              "reference": "UNKNOWN_SOURCE_root_childrez_0"
+              "reference": "synthetic_foo-bar-source_root_childrez"
             }
           ]
         }
       ],
       "annotations": [],
-      "parent": "UNKNOWN_SOURCE_root"
+      "parent": "synthetic_foo-bar-source_root"
     },
     {
-      "id": "UNKNOWN_SOURCE_root_childrez_1",
+      "id": "synthetic_foo-bar-source_root_childrez_1",
       "classifier": {
         "language": "com-strumenta-SimpleLang",
         "version": "1",
@@ -159,10 +160,10 @@ class LionWebModelConverterTest {
       ],
       "references": [],
       "annotations": [],
-      "parent": "UNKNOWN_SOURCE_root"
+      "parent": "synthetic_foo-bar-source_root"
     },
     {
-      "id": "UNKNOWN_SOURCE_root_childrez_2",
+      "id": "synthetic_foo-bar-source_root_childrez_2",
       "classifier": {
         "language": "com-strumenta-SimpleLang",
         "version": "1",
@@ -186,7 +187,7 @@ class LionWebModelConverterTest {
             "key": "com-strumenta-SimpleLang_SimpleNodeA_child"
           },
           "children": [
-            "UNKNOWN_SOURCE_root_childrez_2_child"
+            "synthetic_foo-bar-source_root_childrez_2_child"
           ]
         },
         {
@@ -208,16 +209,16 @@ class LionWebModelConverterTest {
           "targets": [
             {
               "resolveInfo": "A1",
-              "reference": "UNKNOWN_SOURCE_root_childrez_0"
+              "reference": "synthetic_foo-bar-source_root_childrez"
             }
           ]
         }
       ],
       "annotations": [],
-      "parent": "UNKNOWN_SOURCE_root"
+      "parent": "synthetic_foo-bar-source_root"
     },
     {
-      "id": "UNKNOWN_SOURCE_root_childrez_2_child",
+      "id": "synthetic_foo-bar-source_root_childrez_2_child",
       "classifier": {
         "language": "com-strumenta-SimpleLang",
         "version": "1",
@@ -245,7 +246,7 @@ class LionWebModelConverterTest {
       ],
       "references": [],
       "annotations": [],
-      "parent": "UNKNOWN_SOURCE_root_childrez_2"
+      "parent": "synthetic_foo-bar-source_root_childrez_2"
     }
   ]
 }"""
@@ -268,6 +269,7 @@ class LionWebModelConverterTest {
                 a3
             )
         )
+        ast.source = SyntheticSource("foo-bar-source")
         ast.assignParents()
 
         val exporter = LionWebModelConverter()
@@ -375,6 +377,7 @@ class LionWebModelConverterTest {
             )
         )
         initialAst.assignParents()
+        initialAst.source = SyntheticSource("ss1")
 
         val lwAST = mConverter.exportModelToLionWeb(initialAst)
         assertEquals(0, lwAST.getChildrenByContainmentName("position").size)
@@ -396,6 +399,7 @@ class LionWebModelConverterTest {
         val b2 = SimpleNodeB("some magic value")
         val a1 = SimpleNodeA("A1", ReferenceByName("A1"), b2)
         a1.assignParents()
+        a1.source = SyntheticSource("ss1")
 
         // if we store b2, child of a1, we expect the parent to be set
         val converter = LionWebModelConverter()

--- a/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProviderTest.kt
+++ b/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProviderTest.kt
@@ -1,6 +1,7 @@
 package com.strumenta.kolasu.lionweb
 
 import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.SyntheticSource
 import com.strumenta.kolasu.model.assignParents
 import com.strumenta.kolasu.traversing.walk
 import junit.framework.TestCase.assertNotNull
@@ -34,6 +35,7 @@ class StructuralLionWebNodeIdProviderTest {
             )
         )
         root.assignParents()
+        root.source = SyntheticSource("ss1")
         val ip = StructuralLionWebNodeIdProvider()
         val encounteredIDs = mutableSetOf<String>()
         root.walk().forEach { node ->
@@ -65,6 +67,8 @@ class StructuralLionWebNodeIdProviderTest {
                 )
             )
         )
+        root.setSourceForTree(SyntheticSource("foo-bar"))
+
         // we do NOT call assignParents
         val ip = StructuralLionWebNodeIdProvider()
         root.walk().forEach { node ->

--- a/semantics/src/main/kotlin/com/strumenta/kolasu/semantics/symbol/provider/declarative/DeclarativeSymbolProvider.kt
+++ b/semantics/src/main/kotlin/com/strumenta/kolasu/semantics/symbol/provider/declarative/DeclarativeSymbolProvider.kt
@@ -137,7 +137,9 @@ class DeclarativeSymbolProviderRule<NodeTy : Node>(
         nodeIdProvider: NodeIdProvider,
         source: ReferenceByName<*>
     ): ReferenceValueDescription {
-        return ReferenceValueDescription(source.referred?.let { it as? Node }?.let { nodeIdProvider.id(it) })
+        return ReferenceValueDescription(
+            source.referred?.let { it as? Node }?.let { nodeIdProvider.id(it) }
+        )
     }
 
     private fun toContainmentValueDescription(


### PR DESCRIPTION
When calculating the ID of a Node we may need to specify the coordinates in which the Node is going to be inserted. This is useful for example when defining a Node to be inserted within an existing tree in a LionWeb Repository. Locally the Node may not have a parent, but it will eventually get one and ID Logic may want to consider the ID of the parent that the Node is going to be attached to