### PR TITLE
Revise support for converting enum values to and from LionWeb

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,6 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 jvm_version=1.8
 junit_version=4.13.2
 gson_version=2.10.1
-lionwebVersion=0.2.10
+lionwebVersion=0.2.11
 kspVersion=1.0.11
 lionwebGenGradlePluginID=com.strumenta.kolasu.lionwebgen

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProvider.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StructuralLionWebNodeIdProvider.kt
@@ -16,7 +16,7 @@ class StructuralLionWebNodeIdProvider(sourceIdProvider: SourceIdProvider = Simpl
     override fun idUsingCoordinates(kNode: Node, coordinates: Coordinates): String {
         val id = super.idUsingCoordinates(kNode, coordinates)
         if (!CommonChecks.isValidID(id)) {
-            throw IllegalStateException("An invalid LionWeb Node ID has been produced")
+            throw IllegalStateException("An invalid LionWeb Node ID has been produced: $id. Produced for $kNode")
         }
         return id
     }

--- a/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverterTest.kt
+++ b/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverterTest.kt
@@ -11,7 +11,7 @@ import com.strumenta.kolasu.model.assignParents
 import com.strumenta.kolasu.model.withPosition
 import com.strumenta.kolasu.testing.assertASTsAreEqual
 import io.lionweb.lioncore.java.language.Concept
-import io.lionweb.lioncore.java.language.EnumerationLiteral
+import io.lionweb.lioncore.java.model.impl.EnumerationValue
 import io.lionweb.lioncore.java.serialization.JsonSerialization
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -454,13 +454,17 @@ class LionWebModelConverterTest {
         val exportedN3 = converter.exportModelToLionWeb(n3)
         val exportedN4 = converter.exportModelToLionWeb(n4)
 
-        assertTrue(exportedN1.getPropertyValueByName("e") is EnumerationLiteral)
-        assertEquals("BAR", (exportedN1.getPropertyValueByName("e") as EnumerationLiteral).name)
-        assertTrue(exportedN2.getPropertyValueByName("e") is EnumerationLiteral)
-        assertEquals("FOO", (exportedN2.getPropertyValueByName("e") as EnumerationLiteral).name)
-        assertTrue(exportedN3.getPropertyValueByName("e") is EnumerationLiteral)
-        assertEquals("ZUM", (exportedN3.getPropertyValueByName("e") as EnumerationLiteral).name)
+        assertTrue(exportedN1.getPropertyValueByName("e") is EnumerationValue)
+        assertEquals("BAR", (exportedN1.getPropertyValueByName("e") as EnumerationValue).enumerationLiteral.name)
+        assertTrue(exportedN2.getPropertyValueByName("e") is EnumerationValue)
+        assertEquals("FOO", (exportedN2.getPropertyValueByName("e") as EnumerationValue).enumerationLiteral.name)
+        assertTrue(exportedN3.getPropertyValueByName("e") is EnumerationValue)
+        assertEquals("ZUM", (exportedN3.getPropertyValueByName("e") as EnumerationValue).enumerationLiteral.name)
         assertEquals(null, exportedN4.getPropertyValueByName("e"))
+
+        val jsonSerialization = JsonSerialization.getStandardSerialization()
+        converter.prepareJsonSerialization(jsonSerialization)
+        jsonSerialization.serializeTreesToJsonString(exportedN1)
     }
 
     @Test


### PR DESCRIPTION
We update to a new version of LionWeb Java and revise consequently support for serializing enum values.
We added a check from https://github.com/Strumenta/kolasu/pull/321, too.