### PR TITLE
Handle deserialization of properties NOT set at construction time

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Naming.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Naming.kt
@@ -41,7 +41,7 @@ interface Named : PossiblyNamed {
  * actual node at a later stage.
  */
 class ReferenceByName<N : PossiblyNamed>(
-    val name: String,
+    var name: String,
     initialReferred: N? = null,
     var identifier: String? = null
 ) : Serializable {

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -259,10 +259,6 @@ class LionWebModelConverter(
         }
         lwTree.thisAndAllDescendants().forEach { lwNode ->
             val kNode = nodesMapping.byB(lwNode)!!
-//            // TODO populate values not already set at construction time
-//            kNode.javaClass.processProperties { propertyDescription ->
-//                propertyDescription.
-//            }
             if (kNode is KNode) {
                 val lwPosition = lwNode.getOnlyChildByContainmentName("position")
                 if (lwPosition != null) {
@@ -543,9 +539,14 @@ class LionWebModelConverter(
                         val value = attributeValue(data, feature as Property)
                         property.setter.call(kNode, value)
                     }
-
-                    property.isReference() -> TODO()
-                    property.isContainment() -> TODO()
+                    property.isReference() -> {
+                        val valueToSet = referenceValue(data, feature as Reference, referencesPostponer) as ReferenceByName<PossiblyNamed>
+                        property.setter.call(kNode, valueToSet)
+                    }
+                    property.isContainment() -> {
+                        val valueToSet = containmentValue(data, feature as Containment) as List<KNode>
+                        property.setter.call(kNode, valueToSet)
+                    }
                 }
             }
         }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -20,7 +20,6 @@ import io.lionweb.lioncore.java.language.Classifier
 import io.lionweb.lioncore.java.language.Concept
 import io.lionweb.lioncore.java.language.Containment
 import io.lionweb.lioncore.java.language.Enumeration
-import io.lionweb.lioncore.java.language.Feature
 import io.lionweb.lioncore.java.language.Language
 import io.lionweb.lioncore.java.language.LionCoreBuiltins
 import io.lionweb.lioncore.java.language.PrimitiveType
@@ -369,8 +368,8 @@ class LionWebModelConverter(
             }
         }
     }
-    
-    private fun attributeValue(data: LWNode, property: Property) : Any? {
+
+    private fun attributeValue(data: LWNode, property: Property): Any? {
         val propValue = data.getPropertyValue(property)
         val value = if (property.type is Enumeration && propValue != null) {
             val enumerationLiteral = if (propValue is EnumerationValue) {
@@ -378,7 +377,7 @@ class LionWebModelConverter(
             } else {
                 throw java.lang.IllegalStateException(
                     "Property value of property of enumeration type is " +
-                            "not an EnumerationValue. It is instead " + propValue
+                        "not an EnumerationValue. It is instead " + propValue
                 )
             }
             val enumKClass = synchronized(languageConverter) {
@@ -395,7 +394,7 @@ class LionWebModelConverter(
         return value
     }
 
-    private fun containmentValue(data: LWNode, containment: Containment) : Any? {
+    private fun containmentValue(data: LWNode, containment: Containment): Any? {
         val lwChildren = data.getChildren(containment)
         if (containment.isMultiple) {
             val kChildren = lwChildren.map { nodesMapping.byB(it)!! }
@@ -420,17 +419,21 @@ class LionWebModelConverter(
                 return null
             } else {
                 (
-                        return nodesMapping.byB(lwChild)
-                            ?: throw IllegalStateException(
-                                "Unable to find Kolasu Node corresponding to $lwChild"
-                            )
+                    return nodesMapping.byB(lwChild)
+                        ?: throw IllegalStateException(
+                            "Unable to find Kolasu Node corresponding to $lwChild"
                         )
+                    )
             }
         }
     }
 
-    private fun referenceValue(data: LWNode, reference: Reference, referencesPostponer: ReferencesPostponer,
-                               currentValue: ReferenceByName<PossiblyNamed>? = null) : Any? {
+    private fun referenceValue(
+        data: LWNode,
+        reference: Reference,
+        referencesPostponer: ReferencesPostponer,
+        currentValue: ReferenceByName<PossiblyNamed>? = null
+    ): Any? {
         val referenceValues = data.getReferenceValues(reference)
         return when {
             referenceValues.size > 1 -> {
@@ -449,8 +452,11 @@ class LionWebModelConverter(
         }
     }
 
-    private fun <T : Any> instantiate(kClass: KClass<T>, data: Node,
-                                      referencesPostponer: ReferencesPostponer):
+    private fun <T : Any> instantiate(
+        kClass: KClass<T>,
+        data: Node,
+        referencesPostponer: ReferencesPostponer
+    ):
         T {
         if (kClass == Position::class) {
             val start = instantiate(
@@ -509,13 +515,16 @@ class LionWebModelConverter(
         } catch (e: Exception) {
             throw RuntimeException(
                 "Issue instantiating using constructor $constructor with params " +
-                        "${params.map { "${it.key.name}=${it.value}" }}",
+                    "${params.map { "${it.key.name}=${it.value}" }}",
                 e
             )
         }
 
-        val propertiesNotSetAtConstructionTime = kClass.nodeOriginalProperties.filter { prop -> params.keys.none { param ->
-            param.name == prop.name } }
+        val propertiesNotSetAtConstructionTime = kClass.nodeOriginalProperties.filter { prop ->
+            params.keys.none { param ->
+                param.name == prop.name
+            }
+        }
         propertiesNotSetAtConstructionTime.forEach { property ->
             val feature = data.concept.getFeatureByName(property.name!!)
             if (property !is KMutableProperty<*>) {
@@ -526,12 +535,15 @@ class LionWebModelConverter(
                     currentValue.addAll(valueToSet)
                 } else if (property.isReference()) {
                     val currentValue = property.get(kNode) as ReferenceByName<PossiblyNamed>
-                    val valueToSet = referenceValue(data, feature as Reference, referencesPostponer, currentValue) as ReferenceByName<PossiblyNamed>
+                    val valueToSet = referenceValue(data, feature as Reference, referencesPostponer, currentValue)
+                        as ReferenceByName<PossiblyNamed>
                     currentValue.name = valueToSet.name
                     currentValue.referred = valueToSet.referred
                     currentValue.identifier = valueToSet.identifier
                 } else {
-                    throw java.lang.IllegalStateException("Cannot set this property, as it is immutable: ${property.name}")
+                    throw java.lang.IllegalStateException(
+                        "Cannot set this property, as it is immutable: ${property.name}"
+                    )
                 }
             } else {
                 when {
@@ -540,7 +552,8 @@ class LionWebModelConverter(
                         property.setter.call(kNode, value)
                     }
                     property.isReference() -> {
-                        val valueToSet = referenceValue(data, feature as Reference, referencesPostponer) as ReferenceByName<PossiblyNamed>
+                        val valueToSet = referenceValue(data, feature as Reference, referencesPostponer)
+                            as ReferenceByName<PossiblyNamed>
                         property.setter.call(kNode, valueToSet)
                     }
                     property.isContainment() -> {

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -3,17 +3,24 @@ package com.strumenta.kolasu.lionweb
 import com.strumenta.kolasu.ids.IDGenerationException
 import com.strumenta.kolasu.ids.NodeIdProvider
 import com.strumenta.kolasu.language.KolasuLanguage
+import com.strumenta.kolasu.model.Multiplicity
 import com.strumenta.kolasu.model.Point
 import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.model.PossiblyNamed
 import com.strumenta.kolasu.model.ReferenceByName
 import com.strumenta.kolasu.model.allFeatures
+import com.strumenta.kolasu.model.asContainment
 import com.strumenta.kolasu.model.assignParents
+import com.strumenta.kolasu.model.isAttribute
+import com.strumenta.kolasu.model.isContainment
+import com.strumenta.kolasu.model.isReference
+import com.strumenta.kolasu.model.nodeOriginalProperties
 import com.strumenta.kolasu.traversing.walk
 import io.lionweb.lioncore.java.language.Classifier
 import io.lionweb.lioncore.java.language.Concept
 import io.lionweb.lioncore.java.language.Containment
 import io.lionweb.lioncore.java.language.Enumeration
+import io.lionweb.lioncore.java.language.Feature
 import io.lionweb.lioncore.java.language.Language
 import io.lionweb.lioncore.java.language.LionCoreBuiltins
 import io.lionweb.lioncore.java.language.PrimitiveType
@@ -33,6 +40,7 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlin.IllegalStateException
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
+import kotlin.reflect.KMutableProperty
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.primaryConstructor
 
@@ -95,6 +103,7 @@ class LionWebModelConverter(
         nodeIdProvider: NodeIdProvider = this.nodeIdProvider,
         considerParent: Boolean = true
     ): LWNode {
+        kolasuTree.assignParents()
         val myIDManager = object {
 
             fun nodeId(kNode: KNode): String {
@@ -250,7 +259,10 @@ class LionWebModelConverter(
         }
         lwTree.thisAndAllDescendants().forEach { lwNode ->
             val kNode = nodesMapping.byB(lwNode)!!
-            // TODO populate values not already set at construction time
+//            // TODO populate values not already set at construction time
+//            kNode.javaClass.processProperties { propertyDescription ->
+//                propertyDescription.
+//            }
             if (kNode is KNode) {
                 val lwPosition = lwNode.getOnlyChildByContainmentName("position")
                 if (lwPosition != null) {
@@ -361,20 +373,100 @@ class LionWebModelConverter(
             }
         }
     }
+    
+    private fun attributeValue(data: LWNode, property: Property) : Any? {
+        val propValue = data.getPropertyValue(property)
+        val value = if (property.type is Enumeration && propValue != null) {
+            val enumerationLiteral = if (propValue is EnumerationValue) {
+                propValue.enumerationLiteral
+            } else {
+                throw java.lang.IllegalStateException(
+                    "Property value of property of enumeration type is " +
+                            "not an EnumerationValue. It is instead " + propValue
+                )
+            }
+            val enumKClass = synchronized(languageConverter) {
+                languageConverter
+                    .getEnumerationsToKolasuClassesMapping()[enumerationLiteral.enumeration]
+                    ?: throw java.lang.IllegalStateException()
+            }
+            val entries = enumKClass.java.enumConstants
+            entries.find { it.name == enumerationLiteral.name }
+                ?: throw IllegalStateException()
+        } else {
+            propValue
+        }
+        return value
+    }
 
-    private fun <T : Any> instantiate(kClass: KClass<T>, data: Node, referencesPostponer: ReferencesPostponer):
+    private fun containmentValue(data: LWNode, containment: Containment) : Any? {
+        val lwChildren = data.getChildren(containment)
+        if (containment.isMultiple) {
+            val kChildren = lwChildren.map { nodesMapping.byB(it)!! }
+            return kChildren
+        } else {
+            // Given we navigate the tree in reverse the child should have been already
+            // instantiated
+            val lwChild: Node? = when (lwChildren.size) {
+                0 -> {
+                    null
+                }
+
+                1 -> {
+                    lwChildren.first()
+                }
+
+                else -> {
+                    throw IllegalStateException()
+                }
+            }
+            val kChild = if (lwChild == null) {
+                return null
+            } else {
+                (
+                        return nodesMapping.byB(lwChild)
+                            ?: throw IllegalStateException(
+                                "Unable to find Kolasu Node corresponding to $lwChild"
+                            )
+                        )
+            }
+        }
+    }
+
+    private fun referenceValue(data: LWNode, reference: Reference, referencesPostponer: ReferencesPostponer,
+                               currentValue: ReferenceByName<PossiblyNamed>? = null) : Any? {
+        val referenceValues = data.getReferenceValues(reference)
+        return when {
+            referenceValues.size > 1 -> {
+                throw IllegalStateException()
+            }
+            referenceValues.size == 0 -> {
+                null
+            }
+            referenceValues.size == 1 -> {
+                val rf = referenceValues.first()
+                val referenceByName = currentValue ?: ReferenceByName<PossiblyNamed>(rf.resolveInfo!!, null)
+                referencesPostponer.registerPostponedReference(referenceByName, rf.referred)
+                referenceByName
+            }
+            else -> throw java.lang.IllegalStateException()
+        }
+    }
+
+    private fun <T : Any> instantiate(kClass: KClass<T>, data: Node,
+                                      referencesPostponer: ReferencesPostponer):
         T {
         if (kClass == Position::class) {
             val start = instantiate(
                 Point::class,
                 data.getOnlyChildByContainmentName("start")!!,
                 referencesPostponer
-            ) as Point
+            )
             val end = instantiate(
                 Point::class,
                 data.getOnlyChildByContainmentName("end")!!,
                 referencesPostponer
-            ) as Point
+            )
             return Position(start, end) as T
         }
         if (kClass == Point::class) {
@@ -403,92 +495,62 @@ class LionWebModelConverter(
             } else {
                 when (feature) {
                     is Property -> {
-                        val propValue = data.getPropertyValue(feature)
-                        val value = if (feature.type is Enumeration && propValue != null) {
-                            val enumerationLiteral = if (propValue is EnumerationValue) {
-                                propValue.enumerationLiteral
-                            } else {
-                                throw java.lang.IllegalStateException(
-                                    "Property value of property of enumeration type is " +
-                                        "not an EnumerationValue. It is instead " + propValue
-                                )
-                            }
-                            val enumKClass = synchronized(languageConverter) {
-                                languageConverter
-                                    .getEnumerationsToKolasuClassesMapping()[enumerationLiteral.enumeration]
-                                    ?: throw java.lang.IllegalStateException()
-                            }
-                            val entries = enumKClass.java.enumConstants
-                            entries.find { it.name == enumerationLiteral.name }
-                                ?: throw IllegalStateException()
-                        } else {
-                            propValue
-                        }
-
-                        params[param] = value
+                        params[param] = attributeValue(data, feature)
                     }
                     is Reference -> {
-                        val referenceValues = data.getReferenceValues(feature)
-                        when {
-                            referenceValues.size > 1 -> {
-                                throw IllegalStateException()
-                            }
-                            referenceValues.size == 0 -> {
-                                params[param] = null
-                            }
-                            referenceValues.size == 1 -> {
-                                val rf = referenceValues.first()
-                                val referenceByName = ReferenceByName<PossiblyNamed>(rf.resolveInfo!!, null)
-                                referencesPostponer.registerPostponedReference(referenceByName, rf.referred)
-                                params[param] = referenceByName
-                            }
-                        }
+                        params[param] = referenceValue(data, feature, referencesPostponer)
                     }
                     is Containment -> {
-                        val lwChildren = data.getChildren(feature)
-                        if (feature.isMultiple) {
-                            val kChildren = lwChildren.map { nodesMapping.byB(it)!! }
-                            params[param] = kChildren
-                        } else {
-                            // Given we navigate the tree in reverse the child should have been already
-                            // instantiated
-                            val lwChild: Node? = when (lwChildren.size) {
-                                0 -> {
-                                    null
-                                }
-                                1 -> {
-                                    lwChildren.first()
-                                }
-                                else -> {
-                                    throw IllegalStateException()
-                                }
-                            }
-                            val kChild = if (lwChild == null) {
-                                null
-                            } else {
-                                (
-                                    nodesMapping.byB(lwChild)
-                                        ?: throw IllegalStateException(
-                                            "Unable to find Kolasu Node corresponding to $lwChild"
-                                        )
-                                    )
-                            }
-                            params[param] = kChild
-                        }
+                        params[param] = containmentValue(data, feature)
                     }
                     else -> throw IllegalStateException()
                 }
             }
         }
-        try {
-            return constructor.callBy(params) as T
+
+        val kNode = try {
+            constructor.callBy(params) as T
         } catch (e: Exception) {
             throw RuntimeException(
                 "Issue instantiating using constructor $constructor with params " +
-                    "${params.map { "${it.key.name}=${it.value}" }}",
+                        "${params.map { "${it.key.name}=${it.value}" }}",
                 e
             )
         }
+
+        val propertiesNotSetAtConstructionTime = kClass.nodeOriginalProperties.filter { prop -> params.keys.none { param ->
+            param.name == prop.name } }
+        propertiesNotSetAtConstructionTime.forEach { property ->
+            val feature = data.concept.getFeatureByName(property.name!!)
+            if (property !is KMutableProperty<*>) {
+                if (property.isContainment() && property.asContainment().multiplicity == Multiplicity.MANY) {
+                    val currentValue = property.get(kNode) as MutableList<KNode>
+                    currentValue.clear()
+                    val valueToSet = containmentValue(data, feature as Containment) as List<KNode>
+                    currentValue.addAll(valueToSet)
+                } else if (property.isReference()) {
+                    val currentValue = property.get(kNode) as ReferenceByName<PossiblyNamed>
+                    val valueToSet = referenceValue(data, feature as Reference, referencesPostponer, currentValue) as ReferenceByName<PossiblyNamed>
+                    currentValue.name = valueToSet.name
+                    currentValue.referred = valueToSet.referred
+                    currentValue.identifier = valueToSet.identifier
+                } else {
+                    throw java.lang.IllegalStateException("Cannot set this property, as it is immutable: ${property.name}")
+                }
+            } else {
+                when {
+                    property.isAttribute() -> {
+                        val value = attributeValue(data, feature as Property)
+                        property.setter.call(kNode, value)
+                    }
+
+                    property.isReference() -> TODO()
+                    property.isContainment() -> TODO()
+                }
+            }
+        }
+
+        return kNode
     }
 
     private fun findConcept(kNode: com.strumenta.kolasu.model.Node): Concept {

--- a/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverterTest.kt
+++ b/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverterTest.kt
@@ -506,11 +506,11 @@ class LionWebModelConverterTest {
         }
         val mc = LionWebModelConverter()
         mc.exportLanguageToLionWeb(kl)
-        val n1 = NodeWithPropertiesNotInConstructor("N1","foo")
+        val n1 = NodeWithPropertiesNotInConstructor("N1", "foo")
         n1.b = 10
-        val n2 = NodeWithPropertiesNotInConstructor("N2","bar")
+        val n2 = NodeWithPropertiesNotInConstructor("N2", "bar")
         n2.b = 11
-        val n3 = NodeWithPropertiesNotInConstructor("N3","zum")
+        val n3 = NodeWithPropertiesNotInConstructor("N3", "zum")
         n3.b = 12
         n1.c.add(n2)
         n1.c.add(n3)
@@ -549,11 +549,11 @@ class LionWebModelConverterTest {
         }
         val mc = LionWebModelConverter()
         mc.exportLanguageToLionWeb(kl)
-        val n1 = NodeWithPropertiesNotInConstructorMutableProps("N1","foo")
+        val n1 = NodeWithPropertiesNotInConstructorMutableProps("N1", "foo")
         n1.b = 10
-        val n2 = NodeWithPropertiesNotInConstructorMutableProps("N2","bar")
+        val n2 = NodeWithPropertiesNotInConstructorMutableProps("N2", "bar")
         n2.b = 11
-        val n3 = NodeWithPropertiesNotInConstructorMutableProps("N3","zum")
+        val n3 = NodeWithPropertiesNotInConstructorMutableProps("N3", "zum")
         n3.b = 12
         n1.c.add(n2)
         n1.c.add(n3)

--- a/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverterTest.kt
+++ b/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverterTest.kt
@@ -541,6 +541,49 @@ class LionWebModelConverterTest {
         assertEquals(listOf(), n3deserialized.c.map { it.name })
         assertEquals(null, n3deserialized.r.referred)
     }
+
+    @Test
+    fun whenImportingConsiderAlsoPropertiesNotInConstructorWhichAreMutable() {
+        val kl = KolasuLanguage("my.language").apply {
+            addClass(NodeWithPropertiesNotInConstructorMutableProps::class)
+        }
+        val mc = LionWebModelConverter()
+        mc.exportLanguageToLionWeb(kl)
+        val n1 = NodeWithPropertiesNotInConstructorMutableProps("N1","foo")
+        n1.b = 10
+        val n2 = NodeWithPropertiesNotInConstructorMutableProps("N2","bar")
+        n2.b = 11
+        val n3 = NodeWithPropertiesNotInConstructorMutableProps("N3","zum")
+        n3.b = 12
+        n1.c.add(n2)
+        n1.c.add(n3)
+        n2.r.referred = n3
+        n1.source = SyntheticSource("JustForTest")
+        n1.assignParents()
+        val lwNode = mc.exportModelToLionWeb(n1)
+
+        val n1deserialized = mc.importModelFromLionWeb(lwNode) as NodeWithPropertiesNotInConstructorMutableProps
+        assertEquals("N1", n1deserialized.name)
+        assertEquals("foo", n1deserialized.a)
+        assertEquals(10, n1deserialized.b)
+        assertEquals(listOf("N2", "N3"), n1deserialized.c.map { it.name })
+        assertEquals(null, n1deserialized.r.referred)
+
+        val n2deserialized = n1deserialized.c[0]
+        val n3deserialized = n1deserialized.c[1]
+
+        assertEquals("N2", n2deserialized.name)
+        assertEquals("bar", n2deserialized.a)
+        assertEquals(11, n2deserialized.b)
+        assertEquals(listOf(), n2deserialized.c.map { it.name })
+        assertEquals(n3deserialized, n2deserialized.r.referred)
+
+        assertEquals("N3", n3deserialized.name)
+        assertEquals("zum", n3deserialized.a)
+        assertEquals(12, n3deserialized.b)
+        assertEquals(listOf(), n3deserialized.c.map { it.name })
+        assertEquals(null, n3deserialized.r.referred)
+    }
 }
 
 @ASTRoot(canBeNotRoot = true)
@@ -548,4 +591,11 @@ data class NodeWithPropertiesNotInConstructor(override val name: String, var a: 
     var b: Int = 0
     val c = mutableListOf<NodeWithPropertiesNotInConstructor>()
     val r = ReferenceByName<NodeWithPropertiesNotInConstructor>("")
+}
+
+@ASTRoot(canBeNotRoot = true)
+data class NodeWithPropertiesNotInConstructorMutableProps(override val name: String, var a: String) : Node(), Named {
+    var b: Int = 0
+    var c = mutableListOf<NodeWithPropertiesNotInConstructorMutableProps>()
+    var r = ReferenceByName<NodeWithPropertiesNotInConstructorMutableProps>("")
 }

--- a/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverterTest.kt
+++ b/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverterTest.kt
@@ -497,4 +497,26 @@ class LionWebModelConverterTest {
         assertASTsAreEqual(n3, reimportedN3)
         assertASTsAreEqual(n4, reimportedN4)
     }
+
+    // This verifies Issue #324
+    @Test
+    fun whenImportingConsiderAlsoPropertiesNotInConstructor() {
+        val kl = KolasuLanguage("my.language").apply {
+            addClass(NodeWithPropertiesNotInConstructor::class)
+        }
+        val mc = LionWebModelConverter()
+        mc.exportLanguageToLionWeb(kl)
+        val n1 = NodeWithPropertiesNotInConstructor("foo")
+        n1.b = 10
+        n1.source = SyntheticSource("JustForTest")
+        val json = mc.exportModelToLionWeb(n1)
+        val n1deserialized = mc.importModelFromLionWeb(json) as NodeWithPropertiesNotInConstructor
+        assertEquals("foo", n1deserialized.a)
+        assertEquals(10, n1deserialized.b)
+    }
+}
+
+@ASTRoot
+data class NodeWithPropertiesNotInConstructor(var a: String) : Node() {
+    var b: Int = 0
 }

--- a/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverterTest.kt
+++ b/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverterTest.kt
@@ -506,17 +506,46 @@ class LionWebModelConverterTest {
         }
         val mc = LionWebModelConverter()
         mc.exportLanguageToLionWeb(kl)
-        val n1 = NodeWithPropertiesNotInConstructor("foo")
+        val n1 = NodeWithPropertiesNotInConstructor("N1","foo")
         n1.b = 10
+        val n2 = NodeWithPropertiesNotInConstructor("N2","bar")
+        n2.b = 11
+        val n3 = NodeWithPropertiesNotInConstructor("N3","zum")
+        n3.b = 12
+        n1.c.add(n2)
+        n1.c.add(n3)
+        n2.r.referred = n3
         n1.source = SyntheticSource("JustForTest")
-        val json = mc.exportModelToLionWeb(n1)
-        val n1deserialized = mc.importModelFromLionWeb(json) as NodeWithPropertiesNotInConstructor
+        n1.assignParents()
+        val lwNode = mc.exportModelToLionWeb(n1)
+
+        val n1deserialized = mc.importModelFromLionWeb(lwNode) as NodeWithPropertiesNotInConstructor
+        assertEquals("N1", n1deserialized.name)
         assertEquals("foo", n1deserialized.a)
         assertEquals(10, n1deserialized.b)
+        assertEquals(listOf("N2", "N3"), n1deserialized.c.map { it.name })
+        assertEquals(null, n1deserialized.r.referred)
+
+        val n2deserialized = n1deserialized.c[0]
+        val n3deserialized = n1deserialized.c[1]
+
+        assertEquals("N2", n2deserialized.name)
+        assertEquals("bar", n2deserialized.a)
+        assertEquals(11, n2deserialized.b)
+        assertEquals(listOf(), n2deserialized.c.map { it.name })
+        assertEquals(n3deserialized, n2deserialized.r.referred)
+
+        assertEquals("N3", n3deserialized.name)
+        assertEquals("zum", n3deserialized.a)
+        assertEquals(12, n3deserialized.b)
+        assertEquals(listOf(), n3deserialized.c.map { it.name })
+        assertEquals(null, n3deserialized.r.referred)
     }
 }
 
-@ASTRoot
-data class NodeWithPropertiesNotInConstructor(var a: String) : Node() {
+@ASTRoot(canBeNotRoot = true)
+data class NodeWithPropertiesNotInConstructor(override val name: String, var a: String) : Node(), Named {
     var b: Int = 0
+    val c = mutableListOf<NodeWithPropertiesNotInConstructor>()
+    val r = ReferenceByName<NodeWithPropertiesNotInConstructor>("")
 }


### PR DESCRIPTION
We mostly use data classes that set all properties at construction time. However, we should also initialize the properties that are not set at construction time.

Fix #324 