### PR TITLE
#352 Support for "TODO" placeholder nodes for transpilers

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/codegen/ASTCodeGenerator.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/codegen/ASTCodeGenerator.kt
@@ -15,6 +15,8 @@ import kotlin.reflect.KClass
  */
 abstract class ASTCodeGenerator<R : Node> {
     protected val nodePrinters: MutableMap<KClass<*>, NodePrinter> = HashMap()
+    protected open val failedASTTransformationNodePrinter: NodePrinter?
+        get() = null
     var nodePrinterOverrider: (node: Node) -> NodePrinter? = { _ -> null }
 
     protected abstract fun registerRecordPrinters()
@@ -30,7 +32,7 @@ abstract class ASTCodeGenerator<R : Node> {
     }
 
     fun printToString(ast: R): String {
-        val printerOutput = PrinterOutput(this.nodePrinters, nodePrinterOverrider)
+        val printerOutput = PrinterOutput(this.nodePrinters, nodePrinterOverrider, failedASTTransformationNodePrinter)
         configurePrinter(printerOutput)
         return printerOutput.apply { this.print(ast, prefix, postfix) }.text()
     }

--- a/core/src/main/kotlin/com/strumenta/kolasu/codegen/ASTCodeGenerator.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/codegen/ASTCodeGenerator.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.KClass
  */
 abstract class ASTCodeGenerator<R : Node> {
     protected val nodePrinters: MutableMap<KClass<*>, NodePrinter> = HashMap()
-    protected open val failedASTTransformationNodePrinter: NodePrinter?
+    protected open val placeholderNodePrinter: NodePrinter?
         get() = null
     var nodePrinterOverrider: (node: Node) -> NodePrinter? = { _ -> null }
 
@@ -32,7 +32,7 @@ abstract class ASTCodeGenerator<R : Node> {
     }
 
     fun printToString(ast: R): String {
-        val printerOutput = PrinterOutput(this.nodePrinters, nodePrinterOverrider, failedASTTransformationNodePrinter)
+        val printerOutput = PrinterOutput(this.nodePrinters, nodePrinterOverrider, placeholderNodePrinter)
         configurePrinter(printerOutput)
         return printerOutput.apply { this.print(ast, prefix, postfix) }.text()
     }

--- a/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
@@ -4,7 +4,7 @@ import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.model.START_POINT
 import com.strumenta.kolasu.model.TextFileDestination
-import java.lang.IllegalStateException
+import com.strumenta.kolasu.transformation.FailedASTTransformation
 import kotlin.reflect.KClass
 import kotlin.reflect.full.superclasses
 
@@ -21,7 +21,8 @@ fun interface NodePrinter {
  */
 class PrinterOutput(
     private val nodePrinters: Map<KClass<*>, NodePrinter>,
-    private var nodePrinterOverrider: (node: Node) -> NodePrinter? = { _ -> null }
+    private var nodePrinterOverrider: (node: Node) -> NodePrinter? = { _ -> null },
+    private val failedASTTransformationNodePrinter: NodePrinter? = null
 ) {
     private val sb = StringBuilder()
     private var currentPoint = START_POINT
@@ -98,7 +99,11 @@ class PrinterOutput(
         if (overrider != null) {
             return overrider
         }
-        val properPrinter = nodePrinters[kclass]
+        val properPrinter = if (ast.origin is FailedASTTransformation && failedASTTransformationNodePrinter != null) {
+            failedASTTransformationNodePrinter
+        } else {
+            nodePrinters[kclass]
+        }
         if (properPrinter != null) {
             return properPrinter
         }

--- a/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
@@ -4,7 +4,7 @@ import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.model.START_POINT
 import com.strumenta.kolasu.model.TextFileDestination
-import com.strumenta.kolasu.transformation.FailedASTTransformation
+import com.strumenta.kolasu.transformation.MissingASTTransformation
 import kotlin.reflect.KClass
 import kotlin.reflect.full.superclasses
 
@@ -22,7 +22,7 @@ fun interface NodePrinter {
 class PrinterOutput(
     private val nodePrinters: Map<KClass<*>, NodePrinter>,
     private var nodePrinterOverrider: (node: Node) -> NodePrinter? = { _ -> null },
-    private val failedASTTransformationNodePrinter: NodePrinter? = null
+    private val placeholderNodePrinter: NodePrinter? = null
 ) {
     private val sb = StringBuilder()
     private var currentPoint = START_POINT
@@ -99,8 +99,8 @@ class PrinterOutput(
         if (overrider != null) {
             return overrider
         }
-        val properPrinter = if (ast.origin is FailedASTTransformation && failedASTTransformationNodePrinter != null) {
-            failedASTTransformationNodePrinter
+        val properPrinter = if (ast.origin is MissingASTTransformation && placeholderNodePrinter != null) {
+            placeholderNodePrinter
         } else {
             nodePrinters[kclass]
         }

--- a/core/src/main/kotlin/com/strumenta/kolasu/mapping/ParseTreeToASTTransformer.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/mapping/ParseTreeToASTTransformer.kt
@@ -19,16 +19,17 @@ import kotlin.reflect.KClass
 open class ParseTreeToASTTransformer(
     issues: MutableList<Issue> = mutableListOf(),
     allowGenericNode: Boolean = true,
-    val source: Source? = null
-) : ASTTransformer(issues, allowGenericNode) {
+    val source: Source? = null,
+    throwOnUnmappedNode: Boolean = true
+) : ASTTransformer(issues, allowGenericNode, throwOnUnmappedNode) {
 
     /**
      * Performs the transformation of a node and, recursively, its descendants. In addition to the overridden method,
      * it also assigns the parseTreeNode to the AST node so that it can keep track of its position.
      * However, a node factory can override the parseTreeNode of the nodes it creates (but not the parent).
      */
-    override fun transformIntoNodes(source: Any?, parent: Node?): List<Node> {
-        val transformed = super.transformIntoNodes(source, parent)
+    override fun transformIntoNodes(source: Any?, parent: Node?, expectedType: KClass<out Node>): List<Node> {
+        val transformed = super.transformIntoNodes(source, parent, expectedType)
         return transformed.map { node ->
             if (source is ParserRuleContext) {
                 if (node.origin == null) {

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/GenericNodes.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/GenericNodes.kt
@@ -6,12 +6,14 @@ import com.strumenta.kolasu.traversing.children
 /**
  * A generic AST node. We use it to represent parts of a source tree that we don't know how to translate yet.
  */
+@Deprecated("To be removed in Kolasu 1.6")
 class GenericNode(parent: Node? = null) : Node() {
     init {
         this.parent = parent
     }
 }
 
+@Deprecated("To be removed in Kolasu 1.6")
 fun Node.findGenericNode(): GenericNode? {
     return if (this is GenericNode) this else this.children.firstNotNullOfOrNull { it.findGenericNode() }
 }

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/ASTCodeGeneratorTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/ASTCodeGeneratorTest.kt
@@ -2,6 +2,7 @@ package com.strumenta.kolasu.codegen
 
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.ReferenceByName
+import com.strumenta.kolasu.transformation.FailedASTTransformation
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -59,5 +60,28 @@ class ASTCodeGeneratorTest {
             }
         }.printToString(ex)
         assertEquals("""this.myMethod(YYY, XXX, YYY)""", codeWithNodePrinterOverrider)
+    }
+
+    @Test
+    fun printUntranslatedNodes() {
+        val failedNode = KImport("my.imported.stuff")
+        failedNode.origin = FailedASTTransformation(failedNode)
+        val cu = KCompilationUnit(
+            KPackageDecl("my.splendid.packag"),
+            mutableListOf(failedNode),
+            mutableListOf(KFunctionDeclaration("foo"))
+        )
+        val code = KotlinPrinter().printToString(cu)
+        assertEquals(
+            """package my.splendid.packag
+            |
+            |/* Translation of a node is not yet implemented: com.strumenta.kolasu.codegen.KImport */
+            |
+            |fun foo() {
+            |}
+            |
+            """.trimMargin(),
+            code
+        )
     }
 }

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/ASTCodeGeneratorTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/ASTCodeGeneratorTest.kt
@@ -2,7 +2,7 @@ package com.strumenta.kolasu.codegen
 
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.ReferenceByName
-import com.strumenta.kolasu.transformation.FailedASTTransformation
+import com.strumenta.kolasu.transformation.MissingASTTransformation
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -65,7 +65,7 @@ class ASTCodeGeneratorTest {
     @Test
     fun printUntranslatedNodes() {
         val failedNode = KImport("my.imported.stuff")
-        failedNode.origin = FailedASTTransformation(failedNode)
+        failedNode.origin = MissingASTTransformation(failedNode)
         val cu = KCompilationUnit(
             KPackageDecl("my.splendid.packag"),
             mutableListOf(failedNode),

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
@@ -1,13 +1,13 @@
 package com.strumenta.kolasu.codegen
 
 import com.strumenta.kolasu.model.Node
-import com.strumenta.kolasu.transformation.FailedASTTransformation
+import com.strumenta.kolasu.transformation.MissingASTTransformation
 
 class KotlinPrinter : ASTCodeGenerator<KCompilationUnit>() {
 
-    override val failedASTTransformationNodePrinter: NodePrinter
+    override val placeholderNodePrinter: NodePrinter
         get() = NodePrinter { output: PrinterOutput, ast: Node ->
-            val origin = (ast.origin as FailedASTTransformation).origin
+            val origin = (ast.origin as MissingASTTransformation).origin
             val nodeType = if (origin is Node) {
                 origin.nodeType
             } else {

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
@@ -1,6 +1,20 @@
 package com.strumenta.kolasu.codegen
 
+import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.transformation.FailedASTTransformation
+
 class KotlinPrinter : ASTCodeGenerator<KCompilationUnit>() {
+
+    override val failedASTTransformationNodePrinter: NodePrinter
+        get() = NodePrinter { output: PrinterOutput, ast: Node ->
+            val origin = (ast.origin as FailedASTTransformation).origin
+            val nodeType = if (origin is Node) {
+                origin.nodeType
+            } else {
+                origin?.toString()
+            }
+            output.print("/* Translation of a node is not yet implemented: $nodeType */")
+        }
 
     override fun registerRecordPrinters() {
         recordPrinter<KCompilationUnit> {

--- a/core/src/test/kotlin/com/strumenta/kolasu/transformation/ASTTransformerTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/transformation/ASTTransformerTest.kt
@@ -347,7 +347,7 @@ class ASTTransformerTest {
             ),
             bazRoot1
         )
-        assertIs<FailedASTTransformation>(bazRoot1.stmts[0].origin)
+        assertIs<MissingASTTransformation>(bazRoot1.stmts[0].origin)
     }
 }
 

--- a/core/src/test/kotlin/com/strumenta/kolasu/transformation/ASTTransformerTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/transformation/ASTTransformerTest.kt
@@ -325,11 +325,35 @@ class ASTTransformerTest {
             transformed
         )
     }
+
+    @Test
+    fun testUnmappedNode() {
+        val transformer1 = ASTTransformer(allowGenericNode = false)
+        transformer1.registerNodeFactory(BarRoot::class, BazRoot::class)
+            .withChild(BazRoot::stmts, BarRoot::stmts)
+        val original = BarRoot(
+            stmts = mutableListOf(
+                BarStmt("a"),
+                BarStmt("b")
+            )
+        )
+        val bazRoot1 = transformer1.transform(original) as BazRoot
+        assertASTsAreEqual(
+            BazRoot(
+                mutableListOf(
+                    BazStmt(null),
+                    BazStmt(null)
+                )
+            ),
+            bazRoot1
+        )
+        assertIs<FailedASTTransformation>(bazRoot1.stmts[0].origin)
+    }
 }
 
 data class BazRoot(var stmts: MutableList<BazStmt> = mutableListOf()) : Node()
 
-data class BazStmt(val desc: String) : Node()
+data class BazStmt(val desc: String? = null) : Node()
 
 data class BarRoot(var stmts: MutableList<BarStmt> = mutableListOf()) : Node()
 data class BarStmt(val desc: String) : Node()


### PR DESCRIPTION
This PR is based on idea n° 3 in #352 by Federico:
- We keep track of the expected type of node of each child property.
- In case no AST transformer is registered for a given source type, we examine the expected node type of the property we're setting; if it's not abstract, we attempt to instantiate it, and fail with an exception if we can't.
- If we can instantiate it, we'll set it's "origin" to an instance of a class representing a failed translation, wrapping the normal origin. The code generator can recognize this and user code has a chance to provide a dedicated `NodePrinter` to handle such cases.
- For abstract node types, the user is expected to register a fallback `NodeFactory` and provide a placeholder node themselves. That could be of a specially designed subclass or a default existing class with the aforementioned "failed translation" origin. Kolasu is not concerned with handling that case: we would otherwise need to maintain an association between each abstract class and the preferred concrete subclass to use, but there's no reason to given we can already use AST Transformers as they are.