### PR TITLE
Support placeholder nodes in Lionweb too

### DIFF
--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebFluentInterface.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebFluentInterface.kt
@@ -1,13 +1,7 @@
 package com.strumenta.kolasu.lionweb
 
 import com.strumenta.kolasu.model.Multiplicity
-import io.lionweb.lioncore.java.language.Classifier
-import io.lionweb.lioncore.java.language.Concept
-import io.lionweb.lioncore.java.language.Containment
-import io.lionweb.lioncore.java.language.Language
-import io.lionweb.lioncore.java.language.PrimitiveType
-import io.lionweb.lioncore.java.language.Property
-import io.lionweb.lioncore.java.language.Reference
+import io.lionweb.lioncore.java.language.*
 import io.lionweb.lioncore.java.model.impl.DynamicNode
 import kotlin.random.Random
 
@@ -144,10 +138,10 @@ private fun Language.keyPrefixForContainedElements(): String {
     return this.key!!.removePrefix("language-").removeSuffix("-key")
 }
 
-private fun Language.idForContainedElement(containedElementName: String): String {
+fun Language.idForContainedElement(containedElementName: String): String {
     return "${this.idPrefixForContainedElements()}-${containedElementName.lwIDCleanedVersion()}-id"
 }
 
-private fun Language.keyForContainedElement(containedElementName: String): String {
+fun Language.keyForContainedElement(containedElementName: String): String {
     return "${this.keyPrefixForContainedElements()}-${containedElementName.lwIDCleanedVersion()}-key"
 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -181,7 +181,7 @@ class LionWebModelConverter(
                                     } else {
                                         throw Exception(
                                             "MissingASTTransformation origin not supported on nodes " +
-                                                    "that are not AbstractClassifierInstances: $lwNode"
+                                                "that are not AbstractClassifierInstances: $lwNode"
                                         )
                                     }
                                 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -168,7 +168,7 @@ class LionWebModelConverter(
                                     val targetID = myIDManager.nodeId(origin)
                                     setOriginalNode(lwNode, targetID)
                                 } else if (origin is MissingASTTransformation) {
-                                    if (lwNode is DynamicNode) {
+                                    if (lwNode is AbstractClassifierInstance<*>) {
                                         val instance = DynamicAnnotationInstance(
                                             StarLasuLWLanguage.PlaceholderNode.id,
                                             StarLasuLWLanguage.PlaceholderNode
@@ -180,7 +180,8 @@ class LionWebModelConverter(
                                         lwNode.addAnnotation(instance)
                                     } else {
                                         throw Exception(
-                                            "MissingASTTransformation origin not supported on non-dynamic node $lwNode"
+                                            "MissingASTTransformation origin not supported on nodes " +
+                                                    "that are not AbstractClassifierInstances: $lwNode"
                                         )
                                     }
                                 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -179,7 +179,9 @@ class LionWebModelConverter(
                                         }
                                         lwNode.addAnnotation(instance)
                                     } else {
-                                        throw Exception("MissingASTTransformation origin not supported on non-dynamic node $lwNode")
+                                        throw Exception(
+                                            "MissingASTTransformation origin not supported on non-dynamic node $lwNode"
+                                        )
                                     }
                                 }
                             } else if (feature == StarLasuLWLanguage.ASTNodeTranspiledNodes) {
@@ -305,7 +307,9 @@ class LionWebModelConverter(
                     require(originalNodeID != null)
                     referencesPostponer.registerPostponedOriginReference(kNode, originalNodeID)
                 }
-                val placeholderNodeAnnotation = lwNode.annotations.find { it.classifier == StarLasuLWLanguage.PlaceholderNode }
+                val placeholderNodeAnnotation = lwNode.annotations.find {
+                    it.classifier == StarLasuLWLanguage.PlaceholderNode
+                }
                 if (placeholderNodeAnnotation != null) {
                     placeholderNodes.add(kNode)
                 }
@@ -650,7 +654,7 @@ class LionWebModelConverter(
             }
         }
         propertiesNotSetAtConstructionTime.forEach { property ->
-            val feature = data.classifier.getFeatureByName(property.name!!)
+            val feature = data.classifier.getFeatureByName(property.name)
             if (property !is KMutableProperty<*>) {
                 if (property.isContainment() && property.asContainment().multiplicity == Multiplicity.MANY) {
                     val currentValue = property.get(kNode) as MutableList<KNode>

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
@@ -1,11 +1,11 @@
 package com.strumenta.kolasu.lionweb
 
 import com.strumenta.kolasu.model.Multiplicity
-import io.lionweb.lioncore.java.language.Concept
-import io.lionweb.lioncore.java.language.Language
-import io.lionweb.lioncore.java.language.PrimitiveType
-import io.lionweb.lioncore.java.language.Property
-import io.lionweb.lioncore.java.language.Reference
+import io.lionweb.lioncore.java.language.*
+import io.lionweb.lioncore.java.language.Annotation
+import io.lionweb.lioncore.java.self.LionCore
+
+private const val PLACEHOLDER_NODE = "PlaceholderNode"
 
 object StarLasuLWLanguage : Language("com.strumenta.StarLasu") {
 
@@ -21,6 +21,15 @@ object StarLasuLWLanguage : Language("com.strumenta.StarLasu") {
         }
         astNode.addReference("originalNode", astNode, Multiplicity.OPTIONAL)
         astNode.addReference("transpiledNode", astNode, Multiplicity.MANY)
+
+        val placeholderNodeAnnotation = Annotation(
+            this,
+            PLACEHOLDER_NODE,
+            idForContainedElement(PLACEHOLDER_NODE),
+            keyForContainedElement(PLACEHOLDER_NODE)
+            )
+        placeholderNodeAnnotation.annotates = LionCore.getConcept()
+        addElement(placeholderNodeAnnotation)
     }
 
     val Point: PrimitiveType
@@ -43,4 +52,7 @@ object StarLasuLWLanguage : Language("com.strumenta.StarLasu") {
 
     val char: PrimitiveType
         get() = StarLasuLWLanguage.getPrimitiveTypeByName("Char")!!
+
+    val PlaceholderNode: Annotation
+        get() = StarLasuLWLanguage.elements.filterIsInstance<Annotation>().find { it.name == PLACEHOLDER_NODE }!!
 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
@@ -22,13 +22,27 @@ object StarLasuLWLanguage : Language("com.strumenta.StarLasu") {
         astNode.addReference("originalNode", astNode, Multiplicity.OPTIONAL)
         astNode.addReference("transpiledNode", astNode, Multiplicity.MANY)
 
+        addPlaceholderNodeAnnotation(astNode)
+    }
+
+    private fun addPlaceholderNodeAnnotation(astNode: Concept) {
         val placeholderNodeAnnotation = Annotation(
             this,
             PLACEHOLDER_NODE,
             idForContainedElement(PLACEHOLDER_NODE),
             keyForContainedElement(PLACEHOLDER_NODE)
-            )
+        )
         placeholderNodeAnnotation.annotates = LionCore.getConcept()
+        val reference =
+            Reference().apply {
+                this.name = "originalNode"
+                this.id = "${placeholderNodeAnnotation.id!!.removeSuffix("-id")}-$name-id"
+                this.key = "${placeholderNodeAnnotation.key!!.removeSuffix("-key")}-$name-key"
+                this.type = astNode
+                this.setOptional(true)
+                this.setMultiple(false)
+            }
+        placeholderNodeAnnotation.addFeature(reference)
         addElement(placeholderNodeAnnotation)
     }
 
@@ -55,4 +69,7 @@ object StarLasuLWLanguage : Language("com.strumenta.StarLasu") {
 
     val PlaceholderNode: Annotation
         get() = StarLasuLWLanguage.elements.filterIsInstance<Annotation>().find { it.name == PLACEHOLDER_NODE }!!
+
+    val PlaceholderNodeOriginalNode: Reference
+        get() = PlaceholderNode.getReferenceByName("originalNode")!!
 }


### PR DESCRIPTION
We represent placeholder nodes in Lionweb as regular nodes with:

- A _PlaceholderNode_ annotation on them
- Their origin set to the _PlaceholderNode_'s origin (could also be null).
 
Note that this only works for dynamic nodes (see https://github.com/LionWeb-io/lionweb-java/issues/153)