### PR TITLE
Closes #359 - Adds an ASTParserInstantiator interface relaxing the constraints imposed by KolasuParserInstantiator

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/ASTParserInstantiator.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/ASTParserInstantiator.kt
@@ -1,0 +1,13 @@
+package com.strumenta.kolasu.parsing
+
+import java.io.File
+
+/**
+ * This interface is used when need to configure parsers. For example, it can be used for testing, when we need
+ * to instantiate a parser with a particular configuration (e.g. specifying include lists of files).
+ * With respect to [KolasuParserInstantiator], this interface can be used to create more generic [ASTParser].instances.
+ **/
+interface ASTParserInstantiator {
+    fun instantiate(fileToParse: File): ASTParser<*>
+    fun instantiate(code: String): ASTParser<*>
+}

--- a/core/src/main/kotlin/com/strumenta/kolasu/parsing/KolasuParserInstantiator.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/parsing/KolasuParserInstantiator.kt
@@ -5,8 +5,9 @@ import java.io.File
 /**
  * This interface is used when we need to configure parsers. For example, it can be used for testing, when we need
  * to instantiate a parser with a particular configuration (e.g., specifying include lists of files).
+ * With respect to [ASTParserInstantiator] this interface can be used to create more specific [KolasuParser] instances.
  */
-interface KolasuParserInstantiator {
-    fun instantiate(fileToParse: File): KolasuParser<*, *, *, *>
-    fun instantiate(code: String): KolasuParser<*, *, *, *>
+interface KolasuParserInstantiator : ASTParserInstantiator {
+    override fun instantiate(fileToParse: File): KolasuParser<*, *, *, *>
+    override fun instantiate(code: String): KolasuParser<*, *, *, *>
 }

--- a/semantics/build.gradle.kts
+++ b/semantics/build.gradle.kts
@@ -34,8 +34,8 @@ publishing {
             val snapshotRepo = URI("https://oss.sonatype.org/content/repositories/snapshots/")
             url = releaseRepo.takeIf { isReleaseVersion } ?: snapshotRepo
             credentials {
-                username = project.property("ossrhTokenUsername") as String? ?: "Unknown user"
-                password = project.property("ossrhTokenPassword") as String? ?: "Unknown password"
+                username = project.findProperty("ossrhTokenUsername") as String? ?: "Unknown user"
+                password = project.findProperty("ossrhTokenPassword") as String? ?: "Unknown password"
             }
         }
     }


### PR DESCRIPTION
Closes #359 - Adds an ASTParserInstantiator interface relaxing the constraints imposed by KolasuParserInstantiator

This PR introduces the following changes:
- Introduces an `ASTParserInstantiator` interface used to create `ASTParser` instances
- Modifies the existing `KolasuParserInstantiator` interface to extend the newly introduced one
