### PR TITLE
Properly support marker interfaces in Lionweb

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/language/KolasuLanguage.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/language/KolasuLanguage.kt
@@ -1,5 +1,6 @@
 package com.strumenta.kolasu.language
 
+import com.strumenta.kolasu.model.CommonElement
 import com.strumenta.kolasu.model.Named
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.PossiblyNamed
@@ -65,7 +66,7 @@ class KolasuLanguage(val qualifiedName: String) {
 
     fun tentativeAddInterfaceClass(
         kClass: KClass<*>,
-        exceptions: MutableList<Exception> = mutableListOf<Exception>()
+        exceptions: MutableList<Exception> = mutableListOf()
     ): Attempt<Boolean, Exception> {
         if (!_astClasses.contains(kClass) && _astClasses.add(kClass)) {
             kClass.supertypes.forEach { superType -> processSuperType(superType, exceptions) }
@@ -75,7 +76,7 @@ class KolasuLanguage(val qualifiedName: String) {
         }
     }
 
-    private fun processSuperType(superType: KType, exceptions: MutableList<Exception> = mutableListOf<Exception>()) {
+    private fun processSuperType(superType: KType, exceptions: MutableList<Exception> = mutableListOf()) {
         // In case the super type is already mapped to another language we may want to not add it into this language,
         // once we introduce the concept of extending languages
         val kClass = superType.classifier as? KClass<*>
@@ -87,7 +88,7 @@ class KolasuLanguage(val qualifiedName: String) {
             Any::class -> Unit
             else -> {
                 if (kClass.java.isInterface) {
-                    if (kClass.isMarkedAsNodeType()) {
+                    if (kClass.isMarkedAsNodeType() && !kClass.isSubclassOf(CommonElement::class)) {
                         tentativeAddInterfaceClass(kClass, exceptions)
                     }
                 } else {

--- a/core/src/main/kotlin/com/strumenta/kolasu/language/KolasuLanguage.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/language/KolasuLanguage.kt
@@ -89,6 +89,7 @@ class KolasuLanguage(val qualifiedName: String) {
             else -> {
                 if (kClass.java.isInterface) {
                     if (kClass.isMarkedAsNodeType() && !kClass.isSubclassOf(CommonElement::class)) {
+                        // Note: CommonElement subclasses are added to the Starlasu LW language manually
                         tentativeAddInterfaceClass(kClass, exceptions)
                     }
                 } else {

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
@@ -1,52 +1,47 @@
 package com.strumenta.kolasu.model
 
+@NodeType
+interface CommonElement
+
 /**
  * Used to mark nodes as statements (instructions used primarily for their side effects)
  */
-@NodeType
-interface Statement
+interface Statement : CommonElement
 
 /**
  * Used to mark nodes as expressions (descriptions of computations producing a value and, possibly, side effects)
  */
-@NodeType
-interface Expression
+interface Expression : CommonElement
 
 /**
  * This should be used for definitions of classes, interfaces, records, structures, and the like.
  */
-@NodeType
-interface EntityDeclaration
+interface EntityDeclaration : CommonElement
 
 /**
  * This should be used for definitions of functions, methods, etc.
  */
-@NodeType
-interface BehaviorDeclaration
+interface BehaviorDeclaration : CommonElement
 
 /**
  * Used to mark nodes as formal parameters (such as function/method parameters, type parameters, etc.)
  */
-@NodeType
-interface Parameter
+interface Parameter : CommonElement
 
 /**
  * This should be used for documentation elements, such as docstrings and Javadoc-style comments
  */
-@NodeType
-interface Documentation
+interface Documentation : CommonElement
 
 /**
  * This should be used for definitions of modules, packages, namespaces, and similar
  */
-@NodeType
-interface EntityGroupDeclaration
+interface EntityGroupDeclaration : CommonElement
 
 /**
  * This should be used for explicit type annotations (e.g. int, String, etc.)
  */
-@NodeType
-interface TypeAnnotation
+interface TypeAnnotation : CommonElement
 
 /**
  * PlaceholderElements can be used to represent elements in code matchers templates and code templates. They represent
@@ -63,8 +58,7 @@ interface TypeAnnotation
  * Conversely, in a code template the PlaceholderElement indicates where to insert parameters provided to populate the
  * template.
  */
-@NodeType
-interface PlaceholderElement {
+interface PlaceholderElement : CommonElement {
     var placeholderName: String?
 
     @property:Internal

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/CommonElements.kt
@@ -1,7 +1,7 @@
 package com.strumenta.kolasu.model
 
 @NodeType
-interface CommonElement
+sealed interface CommonElement
 
 /**
  * Used to mark nodes as statements (instructions used primarily for their side effects)

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Reflection.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Reflection.kt
@@ -11,6 +11,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.full.superclasses
 import kotlin.reflect.full.withNullability
 
 fun <T : Node> T.relevantMemberProperties(
@@ -170,7 +171,8 @@ val KClass<*>.isConceptInterface: Boolean
  * @return is [this] class annotated with NodeType?
  */
 fun KClass<*>.isMarkedAsNodeType(): Boolean {
-    return this.annotations.any { it.annotationClass == NodeType::class }
+    return this.annotations.any { it.annotationClass == NodeType::class } ||
+        this.superclasses.any { it.isMarkedAsNodeType() }
 }
 
 data class PropertyTypeDescription(

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
@@ -1,14 +1,25 @@
 package com.strumenta.kolasu.emf
 
-import com.strumenta.kolasu.model.NodeType
 import com.strumenta.kolasu.model.PropertyTypeDescription
 import com.strumenta.kolasu.model.isANode
+import com.strumenta.kolasu.model.isMarkedAsNodeType
 import com.strumenta.kolasu.model.processProperties
-import org.eclipse.emf.ecore.*
+import org.eclipse.emf.ecore.EClass
+import org.eclipse.emf.ecore.EClassifier
+import org.eclipse.emf.ecore.EDataType
+import org.eclipse.emf.ecore.EEnum
+import org.eclipse.emf.ecore.EGenericType
+import org.eclipse.emf.ecore.EPackage
+import org.eclipse.emf.ecore.ETypeParameter
+import org.eclipse.emf.ecore.ETypedElement
+import org.eclipse.emf.ecore.EcoreFactory
 import org.eclipse.emf.ecore.resource.Resource
-import java.util.*
-import kotlin.reflect.*
-import kotlin.reflect.full.findAnnotations
+import java.util.LinkedList
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.KTypeParameter
+import kotlin.reflect.KTypeProjection
+import kotlin.reflect.KVariance
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.superclasses
 import kotlin.reflect.full.withNullability
@@ -181,7 +192,7 @@ class MetamodelBuilder(
         registerKClassForEClass(kClass, eClass)
 
         kClass.superclasses.forEach {
-            if (it != Any::class && (!it.java.isInterface || it.findAnnotations(NodeType::class).isNotEmpty())) {
+            if (it != Any::class && (!it.java.isInterface || it.isMarkedAsNodeType())) {
                 eClass.eSuperTypes.add(provideClass(it))
             }
         }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebFluentInterface.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebFluentInterface.kt
@@ -1,7 +1,14 @@
 package com.strumenta.kolasu.lionweb
 
 import com.strumenta.kolasu.model.Multiplicity
-import io.lionweb.lioncore.java.language.*
+import io.lionweb.lioncore.java.language.Classifier
+import io.lionweb.lioncore.java.language.Concept
+import io.lionweb.lioncore.java.language.Containment
+import io.lionweb.lioncore.java.language.Interface
+import io.lionweb.lioncore.java.language.Language
+import io.lionweb.lioncore.java.language.PrimitiveType
+import io.lionweb.lioncore.java.language.Property
+import io.lionweb.lioncore.java.language.Reference
 import io.lionweb.lioncore.java.model.impl.DynamicNode
 import kotlin.random.Random
 
@@ -25,6 +32,18 @@ fun Language.addConcept(name: String): Concept {
         )
     this.addElement(concept)
     return concept
+}
+
+fun Language.addInterface(name: String): Interface {
+    val intf =
+        Interface(
+            this,
+            name,
+            this.idForContainedElement(name),
+            this.keyForContainedElement(name)
+        )
+    this.addElement(intf)
+    return intf
 }
 
 fun Language.addPrimitiveType(name: String): PrimitiveType {

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebLanguageConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebLanguageConverter.kt
@@ -4,10 +4,19 @@ import com.strumenta.kolasu.language.Attribute
 import com.strumenta.kolasu.language.Containment
 import com.strumenta.kolasu.language.KolasuLanguage
 import com.strumenta.kolasu.language.Reference
+import com.strumenta.kolasu.model.BehaviorDeclaration
+import com.strumenta.kolasu.model.Documentation
+import com.strumenta.kolasu.model.EntityDeclaration
+import com.strumenta.kolasu.model.EntityGroupDeclaration
+import com.strumenta.kolasu.model.Expression
 import com.strumenta.kolasu.model.Multiplicity
 import com.strumenta.kolasu.model.Named
 import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.Parameter
+import com.strumenta.kolasu.model.PlaceholderElement
 import com.strumenta.kolasu.model.PossiblyNamed
+import com.strumenta.kolasu.model.Statement
+import com.strumenta.kolasu.model.TypeAnnotation
 import com.strumenta.kolasu.model.declaredFeatures
 import com.strumenta.kolasu.model.isConcept
 import com.strumenta.kolasu.model.isConceptInterface
@@ -40,6 +49,15 @@ class LionWebLanguageConverter {
         registerMapping(Node::class, StarLasuLWLanguage.ASTNode)
         registerMapping(Named::class, LionCoreBuiltins.getINamed())
         registerMapping(PossiblyNamed::class, LionCoreBuiltins.getINamed())
+        registerMapping(BehaviorDeclaration::class, StarLasuLWLanguage.BehaviorDeclaration)
+        registerMapping(Documentation::class, StarLasuLWLanguage.Documentation)
+        registerMapping(EntityDeclaration::class, StarLasuLWLanguage.EntityDeclaration)
+        registerMapping(EntityGroupDeclaration::class, StarLasuLWLanguage.EntityGroupDeclaration)
+        registerMapping(Expression::class, StarLasuLWLanguage.Expression)
+        registerMapping(Parameter::class, StarLasuLWLanguage.Parameter)
+        registerMapping(PlaceholderElement::class, StarLasuLWLanguage.PlaceholderElement)
+        registerMapping(Statement::class, StarLasuLWLanguage.Statement)
+        registerMapping(TypeAnnotation::class, StarLasuLWLanguage.TypeAnnotation)
     }
 
     fun exportToLionWeb(kolasuLanguage: KolasuLanguage): LWLanguage {

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
@@ -1,8 +1,13 @@
 package com.strumenta.kolasu.lionweb
 
 import com.strumenta.kolasu.model.Multiplicity
-import io.lionweb.lioncore.java.language.*
 import io.lionweb.lioncore.java.language.Annotation
+import io.lionweb.lioncore.java.language.Concept
+import io.lionweb.lioncore.java.language.Interface
+import io.lionweb.lioncore.java.language.Language
+import io.lionweb.lioncore.java.language.PrimitiveType
+import io.lionweb.lioncore.java.language.Property
+import io.lionweb.lioncore.java.language.Reference
 import io.lionweb.lioncore.java.self.LionCore
 
 private const val PLACEHOLDER_NODE = "PlaceholderNode"
@@ -23,6 +28,16 @@ object StarLasuLWLanguage : Language("com.strumenta.StarLasu") {
         astNode.addReference("transpiledNode", astNode, Multiplicity.MANY)
 
         addPlaceholderNodeAnnotation(astNode)
+
+        addInterface("BehaviorDeclaration")
+        addInterface("Documentation")
+        addInterface("EntityDeclaration")
+        addInterface("EntityGroupDeclaration")
+        addInterface("Expression")
+        addInterface("Parameter")
+        addInterface("PlaceholderElement")
+        addInterface("Statement")
+        addInterface("TypeAnnotation")
     }
 
     private fun addPlaceholderNodeAnnotation(astNode: Concept) {
@@ -72,4 +87,23 @@ object StarLasuLWLanguage : Language("com.strumenta.StarLasu") {
 
     val PlaceholderNodeOriginalNode: Reference
         get() = PlaceholderNode.getReferenceByName("originalNode")!!
+
+    val BehaviorDeclaration: Interface
+        get() = StarLasuLWLanguage.getInterfaceByName("BehaviorDeclaration")!!
+    val Documentation: Interface
+        get() = StarLasuLWLanguage.getInterfaceByName("Documentation")!!
+    val EntityDeclaration: Interface
+        get() = StarLasuLWLanguage.getInterfaceByName("EntityDeclaration")!!
+    val EntityGroupDeclaration: Interface
+        get() = StarLasuLWLanguage.getInterfaceByName("EntityGroupDeclaration")!!
+    val Expression: Interface
+        get() = StarLasuLWLanguage.getInterfaceByName("Expression")!!
+    val Parameter: Interface
+        get() = StarLasuLWLanguage.getInterfaceByName("Parameter")!!
+    val PlaceholderElement: Interface
+        get() = StarLasuLWLanguage.getInterfaceByName("PlaceholderElement")!!
+    val Statement: Interface
+        get() = StarLasuLWLanguage.getInterfaceByName("Statement")!!
+    val TypeAnnotation: Interface
+        get() = StarLasuLWLanguage.getInterfaceByName("TypeAnnotation")!!
 }

--- a/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebLanguageConverterTest.kt
+++ b/lionweb/src/test/kotlin/com/strumenta/kolasu/lionweb/LionWebLanguageConverterTest.kt
@@ -84,6 +84,7 @@ class LionWebLanguageConverterTest {
         assertEquals("SimpleNodeA", simpleNodeA.name)
         assertSame(lwLanguage, simpleNodeA.language)
         assertEquals(simpleDecl, simpleNodeA.extendedConcept)
+        assertEquals(listOf(StarLasuLWLanguage.EntityDeclaration), simpleNodeA.extendedConcept!!.implemented)
         assertEquals(listOf(LionCoreBuiltins.getINamed(), myRelevantInterface), simpleNodeA.implemented)
         assertEquals(false, simpleNodeA.isAbstract)
         assertEquals(2, simpleNodeA.features.size)


### PR DESCRIPTION
Marker interfaces "worked" in Lionweb only because we were using Kolasu classes to deserialize the model and the metamodel. However, marker interfaces weren't being properly reflected in the serialized metamodel and would therefore be invisible to consumers of the metamodel that don't know the Kolasu node classes.

With this PR we fix that.