### PR TITLE
Add support in EMF for all new Marker Interfaces

### DIFF
--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/KolasuMetamodel.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/KolasuMetamodel.kt
@@ -1,5 +1,13 @@
 package com.strumenta.kolasu.emf
 
+import com.strumenta.kolasu.model.BehaviorDeclaration
+import com.strumenta.kolasu.model.Documentation
+import com.strumenta.kolasu.model.EntityDeclaration
+import com.strumenta.kolasu.model.EntityGroupDeclaration
+import com.strumenta.kolasu.model.Expression
+import com.strumenta.kolasu.model.Parameter
+import com.strumenta.kolasu.model.Statement
+import com.strumenta.kolasu.model.TypeAnnotation
 import com.strumenta.kolasu.validation.IssueSeverity
 import com.strumenta.kolasu.validation.IssueType
 import org.eclipse.emf.ecore.EClass
@@ -7,6 +15,7 @@ import org.eclipse.emf.ecore.EPackage
 import org.eclipse.emf.ecore.EcoreFactory
 import org.eclipse.emf.ecore.EcorePackage
 import java.io.File
+import kotlin.reflect.KClass
 
 val STARLASU_METAMODEL by lazy { createStarlasuMetamodel() }
 val ASTNODE_ECLASS by lazy { STARLASU_METAMODEL.eClassifiers.find { it.name == "ASTNode" }!! as EClass }
@@ -85,15 +94,15 @@ private fun createStarlasuMetamodel(): EPackage {
         addContainment("position", position, 0, 1)
     }
 
-    ePackage.createEClass("Statement").apply {
-        this.isInterface = true
-    }
-    ePackage.createEClass("Expression").apply {
-        this.isInterface = true
-    }
-    ePackage.createEClass("EntityDeclaration").apply {
-        this.isInterface = true
-    }
+    ePackage.addCorrespondingTo(Statement::class)
+    ePackage.addCorrespondingTo(Expression::class)
+    ePackage.addCorrespondingTo(EntityDeclaration::class)
+    ePackage.addCorrespondingTo(EntityGroupDeclaration::class)
+    ePackage.addCorrespondingTo(TypeAnnotation::class)
+    ePackage.addCorrespondingTo(BehaviorDeclaration::class)
+    ePackage.addCorrespondingTo(Parameter::class)
+    ePackage.addCorrespondingTo(Documentation::class)
+
     ePackage.createEClass("PlaceholderElement").apply {
         this.isInterface = true
         addAttribute("placeholderName", stringDT, 0, 1)
@@ -196,4 +205,10 @@ fun main() {
     STARLASU_METAMODEL.saveEcore(File("kolasu-2.0.ecore"))
     STARLASU_METAMODEL.saveEcore(File("kolasu-2.0.xmi"))
     STARLASU_METAMODEL.saveAsJson(File("kolasu-2.0.json"))
+}
+
+fun EPackage.addCorrespondingTo(kClass: KClass<*>): EClass {
+    return this.createEClass(kClass.simpleName!!).apply {
+        this.isInterface = kClass.java.isInterface
+    }
 }

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/Metamodel.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/Metamodel.kt
@@ -53,6 +53,16 @@ class KolasuClassHandler(val kolasuKClass: KClass<*>, val kolasuEClass: EClass) 
     }
 
     override fun external(): Boolean = true
+
+    companion object {
+        fun forKClass(kclass: KClass<*>): KolasuClassHandler {
+            return KolasuClassHandler(
+                kclass,
+                STARLASU_METAMODEL
+                    .getEClass(kclass.simpleName!!)
+            )
+        }
+    }
 }
 
 class KolasuDataTypeHandler(val kolasuKClass: KClass<*>, val kolasuDataType: EDataType) : EDataTypeHandler {
@@ -78,18 +88,15 @@ val PossiblyNamedHandler = KolasuClassHandler(PossiblyNamed::class, STARLASU_MET
 val ReferenceByNameHandler = KolasuClassHandler(ReferenceByName::class, STARLASU_METAMODEL.getEClass("ReferenceByName"))
 val ResultHandler = KolasuClassHandler(Result::class, STARLASU_METAMODEL.getEClass("Result"))
 
-val StatementHandler = KolasuClassHandler(Statement::class, STARLASU_METAMODEL.getEClass("Statement"))
-val ExpressionHandler = KolasuClassHandler(Expression::class, STARLASU_METAMODEL.getEClass("Expression"))
-val EntityDeclarationHandler = KolasuClassHandler(
-    EntityDeclaration::class,
-    STARLASU_METAMODEL
-        .getEClass("EntityDeclaration")
-)
-val PlaceholderElementHandler = KolasuClassHandler(
-    PlaceholderElement::class,
-    STARLASU_METAMODEL
-        .getEClass("PlaceholderElement")
-)
+val StatementHandler = KolasuClassHandler.forKClass(Statement::class)
+val ExpressionHandler = KolasuClassHandler.forKClass(Expression::class)
+val EntityDeclarationHandler = KolasuClassHandler.forKClass(EntityDeclaration::class)
+val EntityGroupDeclarationHandler = KolasuClassHandler.forKClass(EntityGroupDeclaration::class)
+val TypeAnnotationHandler = KolasuClassHandler.forKClass(TypeAnnotation::class)
+val PlaceholderElementHandler = KolasuClassHandler.forKClass(PlaceholderElement::class)
+val BehaviorDeclarationHandler = KolasuClassHandler.forKClass(BehaviorDeclaration::class)
+val ParameterHandler = KolasuClassHandler.forKClass(Parameter::class)
+val DocumentationHandler = KolasuClassHandler.forKClass(Documentation::class)
 
 val ErrorNodeHandler = KolasuClassHandler(ErrorNode::class, STARLASU_METAMODEL.getEClass("ErrorNode"))
 val GenericErrorNodeHandler = KolasuClassHandler(

--- a/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
+++ b/emf/src/main/kotlin/com/strumenta/kolasu/emf/MetamodelBuilder.kt
@@ -105,6 +105,11 @@ class MetamodelBuilder(
         eclassTypeHandlers.add(StatementHandler)
         eclassTypeHandlers.add(ExpressionHandler)
         eclassTypeHandlers.add(EntityDeclarationHandler)
+        eclassTypeHandlers.add(EntityGroupDeclarationHandler)
+        eclassTypeHandlers.add(TypeAnnotationHandler)
+        eclassTypeHandlers.add(BehaviorDeclarationHandler)
+        eclassTypeHandlers.add(ParameterHandler)
+        eclassTypeHandlers.add(DocumentationHandler)
         eclassTypeHandlers.add(PlaceholderElementHandler)
 
         eclassTypeHandlers.add(ErrorNodeHandler)

--- a/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
+++ b/emf/src/test/kotlin/com/strumenta/kolasu/emf/cli/EMFCLIToolTest.kt
@@ -474,6 +474,26 @@ class EMFCLIToolTest {
     "interface" : true
   }, {
     "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+    "name" : "EntityGroupDeclaration",
+    "interface" : true
+  }, {
+    "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+    "name" : "TypeAnnotation",
+    "interface" : true
+  }, {
+    "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+    "name" : "BehaviorDeclaration",
+    "interface" : true
+  }, {
+    "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+    "name" : "Parameter",
+    "interface" : true
+  }, {
+    "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+    "name" : "Documentation",
+    "interface" : true
+  }, {
+    "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EClass",
     "name" : "PlaceholderElement",
     "interface" : true,
     "eStructuralFeatures" : [ {


### PR DESCRIPTION
Fix #367 

This is needed to be able to generate the EMF Metamodel for EGL, so that we can release it. We will then update the StarLasu Tools and CIS, then completing [#57 ](https://github.com/Strumenta/code-insight-studio/pull/57)