### PR TITLE
Fault tolerant transformers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
     id 'org.jetbrains.kotlin.jvm' version "${kotlin_version}"
-    id "org.jlleitschuh.gradle.ktlint" version "11.5.1"
+    alias(libs.plugins.ktlint)
     id("maven-publish")
     id("idea")
     id("signing")

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
-    id "org.jlleitschuh.gradle.ktlint"
+    alias(libs.plugins.ktlint)
     id "maven-publish"
     id "antlr"
     id "idea"

--- a/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
@@ -4,8 +4,6 @@ import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.model.START_POINT
 import com.strumenta.kolasu.model.TextFileDestination
-import com.strumenta.kolasu.transformation.FailingASTTransformation
-import com.strumenta.kolasu.transformation.MissingASTTransformation
 import com.strumenta.kolasu.transformation.PlaceholderASTTransformation
 import kotlin.reflect.KClass
 import kotlin.reflect.full.superclasses

--- a/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/codegen/PrinterOutput.kt
@@ -4,7 +4,9 @@ import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.model.START_POINT
 import com.strumenta.kolasu.model.TextFileDestination
+import com.strumenta.kolasu.transformation.FailingASTTransformation
 import com.strumenta.kolasu.transformation.MissingASTTransformation
+import com.strumenta.kolasu.transformation.PlaceholderASTTransformation
 import kotlin.reflect.KClass
 import kotlin.reflect.full.superclasses
 
@@ -99,7 +101,7 @@ class PrinterOutput(
         if (overrider != null) {
             return overrider
         }
-        val properPrinter = if (ast.origin is MissingASTTransformation && placeholderNodePrinter != null) {
+        val properPrinter = if (ast.origin is PlaceholderASTTransformation && placeholderNodePrinter != null) {
             placeholderNodePrinter
         } else {
             nodePrinters[kclass]

--- a/core/src/main/kotlin/com/strumenta/kolasu/ids/CachingNodeIDProvider.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/ids/CachingNodeIDProvider.kt
@@ -28,6 +28,8 @@ class CachingNodeIDProvider(val wrapped: NodeIdProvider) : BaseNodeIdProvider() 
     fun clear() {
         cache.clear()
     }
+
+    override fun toString(): String = "CachingNodeIDProvider with wrapped=$wrapped"
 }
 
 fun NodeIdProvider.caching(): CachingNodeIDProvider = CachingNodeIDProvider(this)

--- a/core/src/main/kotlin/com/strumenta/kolasu/ids/SourceIdProvider.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/ids/SourceIdProvider.kt
@@ -20,6 +20,7 @@ abstract class AbstractSourceIdProvider : SourceIdProvider {
     protected fun cleanId(id: String) = id
         .replace('.', '-')
         .replace('/', '-')
+        .replace('#', '-')
         .replace(' ', '_')
         .replace("@", "_at_")
 }

--- a/core/src/main/kotlin/com/strumenta/kolasu/ids/SourceIdProvider.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/ids/SourceIdProvider.kt
@@ -9,6 +9,14 @@ import java.io.File
 
 const val UNKNOWN_SOURCE_ID = "UNKNOWN_SOURCE"
 
+fun String.removeCharactersInvalidInLionWebIDs(): String {
+    return this.filter {
+        it in setOf('-', '_') || it in CharRange('0', '9') ||
+            it in CharRange('a', 'z') ||
+            it in CharRange('A', 'Z')
+    }.toString()
+}
+
 /**
  * Given a Source (even null), it generates a corresponding identifier.
  */
@@ -22,7 +30,7 @@ abstract class AbstractSourceIdProvider : SourceIdProvider {
         .replace('/', '-')
         .replace('#', '-')
         .replace(' ', '_')
-        .replace("@", "_at_")
+        .replace("@", "_at_").removeCharactersInvalidInLionWebIDs()
 }
 
 class SimpleSourceIdProvider(var acceptNullSource: Boolean = false) : AbstractSourceIdProvider() {

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Errors.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Errors.kt
@@ -19,8 +19,8 @@ class GenericErrorNode(error: Exception? = null, message: String? = null) : Node
 
     private fun Throwable.message(): String {
         val cause = this.cause?.message()?.let { " -> $it" } ?: ""
-        val msg = if (this.message != null) ": " + this.message else ""
-        return "${this.javaClass.simpleName}$msg$cause"
+        val explanation = if (this.message != null) ": " + this.message else ""
+        return "${this.javaClass.simpleName}$explanation$cause"
     }
 }
 

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Errors.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Errors.kt
@@ -15,12 +15,13 @@ interface ErrorNode {
  */
 class GenericErrorNode(error: Exception? = null, message: String? = null) : Node(), ErrorNode {
     override val message: String = message
-        ?: if (error != null) {
-            val msg = if (error.message != null) ": " + error.message else ""
-            "Exception ${error::class.qualifiedName}$msg"
-        } else {
-            "Unspecified error node"
-        }
+        ?: error?.message() ?: "Unspecified error node"
+
+    private fun Throwable.message(): String {
+        val cause = this.cause?.message()?.let { " -> $it" } ?: ""
+        val msg = if (this.message != null) ": " + this.message else ""
+        return "${this.javaClass.simpleName}$msg$cause"
+    }
 }
 
 fun Node.errors(): Sequence<ErrorNode> = this.walkDescendants(ErrorNode::class)

--- a/core/src/main/kotlin/com/strumenta/kolasu/testing/Testing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/testing/Testing.kt
@@ -271,7 +271,11 @@ fun Node.assertReferencesResolved(forProperty: KReferenceByName<out Node>) {
 fun Node.assertReferencesResolved(withReturnType: KClass<out PossiblyNamed> = PossiblyNamed::class) {
     this.kReferenceByNameProperties(targetClass = withReturnType)
         .mapNotNull { it.get(this) }
-        .forEach { assertTrue("Reference $it in node $this at ${this.position} was expected to be solved") { (it as ReferenceByName<*>).resolved } }
+        .forEach {
+            assertTrue("Reference $it in node $this at ${this.position} was expected to be solved") {
+                (it as ReferenceByName<*>).resolved
+            }
+        }
     this.walkChildren().forEach { it.assertReferencesResolved(withReturnType = withReturnType) }
 }
 

--- a/core/src/main/kotlin/com/strumenta/kolasu/testing/Testing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/testing/Testing.kt
@@ -271,7 +271,7 @@ fun Node.assertReferencesResolved(forProperty: KReferenceByName<out Node>) {
 fun Node.assertReferencesResolved(withReturnType: KClass<out PossiblyNamed> = PossiblyNamed::class) {
     this.kReferenceByNameProperties(targetClass = withReturnType)
         .mapNotNull { it.get(this) }
-        .forEach { assertTrue("Reference $it in node $this was expected to be solved") { (it as ReferenceByName<*>).resolved } }
+        .forEach { assertTrue("Reference $it in node $this at ${this.position} was expected to be solved") { (it as ReferenceByName<*>).resolved } }
     this.walkChildren().forEach { it.assertReferencesResolved(withReturnType = withReturnType) }
 }
 

--- a/core/src/main/kotlin/com/strumenta/kolasu/testing/Testing.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/testing/Testing.kt
@@ -271,7 +271,7 @@ fun Node.assertReferencesResolved(forProperty: KReferenceByName<out Node>) {
 fun Node.assertReferencesResolved(withReturnType: KClass<out PossiblyNamed> = PossiblyNamed::class) {
     this.kReferenceByNameProperties(targetClass = withReturnType)
         .mapNotNull { it.get(this) }
-        .forEach { assertTrue { (it as ReferenceByName<*>).resolved } }
+        .forEach { assertTrue("Reference $it in node $this was expected to be solved") { (it as ReferenceByName<*>).resolved } }
     this.walkChildren().forEach { it.assertReferencesResolved(withReturnType = withReturnType) }
 }
 

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/DummyNodes.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/DummyNodes.kt
@@ -12,6 +12,12 @@ import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.javaType
 
+/**
+ * This logic instantiate a node of the given class with dummy values.
+ * This is useful because it permits to add an element that "fit" and make the typesystem happy.
+ * Typically, the only goal of the element would be to hold some annotation that indicates that the element
+ * is representing an error or a missing transformation or something of that sort.
+ */
 fun <T : Node> KClass<T>.dummyInstance(): T {
     val kClassToInstantiate = this.toInstantiableType()
     val emptyConstructor = kClassToInstantiate.constructors.find { it.parameters.isEmpty() }
@@ -77,6 +83,10 @@ private fun <T : Any> KClass<T>.toInstantiableType(): KClass<out T> {
     }
 }
 
+/**
+ * We can only instantiate concrete classes or sealed classes, if one its subclasses is directly or
+ * indirectly instantiable. For interfaces this return false.
+ */
 fun <T : Any> KClass<T>.isDirectlyOrIndirectlyInstantiable(): Boolean {
     return if (this.isSealed) {
         this.sealedSubclasses.any { it.isDirectlyOrIndirectlyInstantiable() }

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/DummyNodes.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/DummyNodes.kt
@@ -1,0 +1,86 @@
+package com.strumenta.kolasu.transformation
+
+import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.PossiblyNamed
+import com.strumenta.kolasu.model.ReferenceByName
+import java.lang.reflect.ParameterizedType
+import kotlin.random.Random
+import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.createType
+import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.javaType
+
+fun <T : Node> KClass<T>.dummyInstance(): T {
+    val kClassToInstantiate = this.toInstantiableType()
+    val emptyConstructor = kClassToInstantiate.constructors.find { it.parameters.isEmpty() }
+    if (emptyConstructor != null) {
+        return emptyConstructor.call()
+    }
+    val constructor = kClassToInstantiate.primaryConstructor!!
+    val params = mutableMapOf<KParameter, Any?>()
+    constructor.parameters.forEach { param ->
+        val mt = param.type.javaType
+        val value = when {
+            param.type.isMarkedNullable -> null
+            mt is ParameterizedType && mt.rawType == List::class.java -> mutableListOf<Any>()
+            (param.type.classifier as KClass<*>).isSubclassOf(Node::class) ->
+                (param.type.classifier as KClass<out Node>).dummyInstance()
+            param.type == String::class.createType() -> "DUMMY"
+            param.type.classifier == ReferenceByName::class -> ReferenceByName<PossiblyNamed>("UNKNOWN")
+            param.type == Int::class.createType() -> 0
+            param.type == Float::class.createType() -> 0.0f
+            param.type == Long::class.createType() -> 0L
+            param.type == Double::class.createType() -> 0.0
+            param.type == Boolean::class.createType() -> false
+            (param.type.classifier as KClass<*>).isSubclassOf(Enum::class)
+            -> (param.type.classifier as KClass<*>).java.enumConstants[0]
+            else -> TODO("Param type ${param.type}")
+        }
+        params[param] = value
+    }
+    return constructor.callBy(params)
+}
+
+private fun <T : Any> KClass<T>.toInstantiableType(): KClass<out T> {
+    return when {
+        this.isSealed -> {
+            val subclasses = this.sealedSubclasses.filter { it.isDirectlyOrIndirectlyInstantiable() }
+            if (subclasses.isEmpty()) {
+                throw IllegalStateException("$this has no instantiable sealed subclasses")
+            }
+            val subClassWithEmptyParam = subclasses.find { it.constructors.any { it.parameters.isEmpty() } }
+            if (subClassWithEmptyParam == null) {
+                if (subclasses.size == 1) {
+                    subclasses.first().toInstantiableType()
+                } else {
+                    // Some constructs are recursive (think of the ArrayType)
+                    // We either find complex logic to find the ones that aren't or just pick one randomly.
+                    // Eventually we will build a tree
+                    val r = Random.Default
+                    subclasses[r.nextInt(subclasses.size)].toInstantiableType()
+                }
+            } else {
+                subClassWithEmptyParam.toInstantiableType()
+            }
+        }
+        this.isAbstract -> {
+            throw IllegalStateException("We cannot instantiate an abstract class (but we can handle sealed classes)")
+        }
+        this.java.isInterface -> {
+            throw IllegalStateException("We cannot instantiate an interface")
+        }
+        else -> {
+            this
+        }
+    }
+}
+
+fun <T : Any> KClass<T>.isDirectlyOrIndirectlyInstantiable(): Boolean {
+    return if (this.isSealed) {
+        this.sealedSubclasses.any { it.isDirectlyOrIndirectlyInstantiable() }
+    } else {
+        !this.isAbstract && !this.java.isInterface
+    }
+}

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/PlaceholderASTTransformation.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/PlaceholderASTTransformation.kt
@@ -3,7 +3,27 @@ package com.strumenta.kolasu.transformation
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Origin
 import com.strumenta.kolasu.model.Position
+import com.strumenta.kolasu.traversing.walkAncestors
 import kotlin.reflect.KClass
+
+/**
+ * This indicates if the Node itself is marked as a placeholder. Note that the Node could not be directly marked
+ * as such and still be the descendants of such type of Node. In other words it could be in a placeholder tree.
+ * This operation is not expensive to perform.
+ */
+val Node.isDirectlyPlaceholderASTTransformation: Boolean
+    get() = this.origin is PlaceholderASTTransformation
+
+/**
+ * This indicates if the Node itself is marked as a placeholder or if any of its ancestors are. Note that the Node
+ * could not be directly marked as such and still be the descendants of such type of Node. In other words it could be
+ * in a placeholder tree.
+ * This operation is expensive to perform.
+ */
+val Node.isDirectlyOrIndirectlyAPlaceholderASTTransformation: Boolean
+    get() = this.isDirectlyPlaceholderASTTransformation || this.walkAncestors().any {
+        it.isDirectlyPlaceholderASTTransformation
+    }
 
 /**
  * This is used to indicate that a Node represents some form of placeholders to be used in transformation.

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/PlaceholderASTTransformation.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/PlaceholderASTTransformation.kt
@@ -1,0 +1,42 @@
+package com.strumenta.kolasu.transformation
+
+import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.Origin
+import com.strumenta.kolasu.model.Position
+import kotlin.reflect.KClass
+
+/**
+ * This is used to indicate that a Node represents some form of placeholders to be used in transformation.
+ */
+sealed class PlaceholderASTTransformation(val origin: Origin?, val message: String) : Origin {
+    override val position: Position?
+        get() = origin?.position
+    override val sourceText: String?
+        get() = origin?.sourceText
+}
+
+/**
+ * This is used to indicate that we do not know how to transform a certain node.
+ */
+class MissingASTTransformation(
+    origin: Origin?,
+    val transformationSource: Any?,
+    val expectedType: KClass<out Node>? = null,
+    message: String = "Translation of a node is not yet implemented: " +
+        "${if (transformationSource is Node) transformationSource.simpleNodeType else transformationSource}" +
+        if (expectedType != null) " into $expectedType" else ""
+) :
+    PlaceholderASTTransformation(origin, message) {
+    constructor(transformationSource: Node, expectedType: KClass<out Node>? = null) : this(
+        transformationSource,
+        transformationSource,
+        expectedType
+    )
+}
+
+/**
+ * This is used to indicate that, while we had a transformation for a given node, that failed.
+ * This is typically the case because the transformation covers only certain case and we encountered
+ * one that was not covered.
+ */
+class FailingASTTransformation(origin: Origin?, message: String) : PlaceholderASTTransformation(origin, message)

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
@@ -238,31 +238,6 @@ data class ChildNodeFactory<Source, Target, Child : Any>(
  */
 private val NO_CHILD_NODE = ChildNodeFactory<Any, Any, Any>("", { x -> x }, { _, _ -> }, Node::class)
 
-sealed class PlaceholderASTTransformation(val origin: Origin?, val message: String) : Origin {
-    override val position: Position?
-        get() = origin?.position
-    override val sourceText: String?
-        get() = origin?.sourceText
-}
-
-class MissingASTTransformation(
-    origin: Origin?,
-    val transformationSource: Any?,
-    val expectedType: KClass<out Node>? = null,
-    message: String = "Translation of a node is not yet implemented: " +
-        "${if (transformationSource is Node) transformationSource.simpleNodeType else transformationSource}" +
-        if (expectedType != null) " into $expectedType" else ""
-) :
-    PlaceholderASTTransformation(origin, message) {
-    constructor(transformationSource: Node, expectedType: KClass<out Node>? = null) : this(
-        transformationSource,
-        transformationSource,
-        expectedType
-    )
-}
-
-class FailingASTTransformation(origin: Origin?, message: String) : PlaceholderASTTransformation(origin, message)
-
 /**
  * Implementation of a tree-to-tree transformation. For each source node type, we can register a factory that knows how
  * to create a transformed node. Then, this transformer can read metadata in the transformed node to recursively
@@ -278,6 +253,11 @@ open class ASTTransformer(
     @Deprecated("To be removed in Kolasu 1.6")
     val allowGenericNode: Boolean = true,
     val throwOnUnmappedNode: Boolean = false,
+    /**
+     * When the fault tollerant flag is set, in case a transformation fails we will add a node
+     * with the origin FailingASTTransformation. If the flag is not set, then the transformation will just
+     * fail.
+     */
     val faultTollerant: Boolean = !throwOnUnmappedNode
 ) {
     /**

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
@@ -455,6 +455,9 @@ open class ASTTransformer(
         crossinline factory: S.(ASTTransformer) -> T?
     ): NodeFactory<S, T> = registerNodeFactory(S::class) { source, transformer, _ -> source.factory(transformer) }
 
+    /**
+     * We need T to be reified because we may need to install dummy classes of T.
+     */
     inline fun <S : Any, reified T : Node> registerNodeFactory(
         kclass: KClass<S>,
         crossinline factory: (S) -> T?
@@ -607,6 +610,10 @@ open class ASTTransformer(
         return nodeFactory
     }
 
+    /**
+     * Here the method needs to be inlined and the type parameter reified as in the invoked
+     * registerNodeFactory we need to access the nodeClass
+     */
     inline fun <reified T : Node> registerIdentityTransformation(nodeClass: KClass<T>) =
         registerNodeFactory(nodeClass) { node -> node }.skipChildren()
 

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/ASTCodeGeneratorTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/ASTCodeGeneratorTest.kt
@@ -2,6 +2,7 @@ package com.strumenta.kolasu.codegen
 
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.ReferenceByName
+import com.strumenta.kolasu.transformation.FailingASTTransformation
 import com.strumenta.kolasu.transformation.MissingASTTransformation
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -75,7 +76,30 @@ class ASTCodeGeneratorTest {
         assertEquals(
             """package my.splendid.packag
             |
-            |/* Translation of a node is not yet implemented: com.strumenta.kolasu.codegen.KImport */
+            |/* Translation of a node is not yet implemented: KImport */
+            |
+            |fun foo() {
+            |}
+            |
+            """.trimMargin(),
+            code
+        )
+    }
+
+    @Test
+    fun printTransformationFailure() {
+        val failedNode = KImport("my.imported.stuff")
+        failedNode.origin = FailingASTTransformation(failedNode, "Something made BOOM!")
+        val cu = KCompilationUnit(
+            KPackageDecl("my.splendid.packag"),
+            mutableListOf(failedNode),
+            mutableListOf(KFunctionDeclaration("foo"))
+        )
+        val code = KotlinPrinter().printToString(cu)
+        assertEquals(
+            """package my.splendid.packag
+            |
+            |/* Something made BOOM! */
             |
             |fun foo() {
             |}

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
@@ -1,7 +1,6 @@
 package com.strumenta.kolasu.codegen
 
 import com.strumenta.kolasu.model.Node
-import com.strumenta.kolasu.transformation.MissingASTTransformation
 import com.strumenta.kolasu.transformation.PlaceholderASTTransformation
 
 class KotlinPrinter : ASTCodeGenerator<KCompilationUnit>() {

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
@@ -9,11 +9,6 @@ class KotlinPrinter : ASTCodeGenerator<KCompilationUnit>() {
         get() = NodePrinter { output: PrinterOutput, ast: Node ->
             val placeholder = ast.origin as PlaceholderASTTransformation
             val origin = placeholder.origin
-            val nodeType = if (origin is Node) {
-                origin.nodeType
-            } else {
-                origin?.toString()
-            }
             output.print("/* ${placeholder.message} */")
         }
 

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
@@ -8,7 +8,6 @@ class KotlinPrinter : ASTCodeGenerator<KCompilationUnit>() {
     override val placeholderNodePrinter: NodePrinter
         get() = NodePrinter { output: PrinterOutput, ast: Node ->
             val placeholder = ast.origin as PlaceholderASTTransformation
-            val origin = placeholder.origin
             output.print("/* ${placeholder.message} */")
         }
 

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
@@ -8,13 +8,14 @@ class KotlinPrinter : ASTCodeGenerator<KCompilationUnit>() {
 
     override val placeholderNodePrinter: NodePrinter
         get() = NodePrinter { output: PrinterOutput, ast: Node ->
-            val origin = (ast.origin as PlaceholderASTTransformation).origin
+            val placeholder = ast.origin as PlaceholderASTTransformation
+            val origin = placeholder.origin
             val nodeType = if (origin is Node) {
                 origin.nodeType
             } else {
                 origin?.toString()
             }
-            output.print("/* Translation of a node is not yet implemented: $nodeType */")
+            output.print("/* ${placeholder.message} */")
         }
 
     override fun registerRecordPrinters() {

--- a/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/codegen/KotlinPrinter.kt
@@ -2,12 +2,13 @@ package com.strumenta.kolasu.codegen
 
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.transformation.MissingASTTransformation
+import com.strumenta.kolasu.transformation.PlaceholderASTTransformation
 
 class KotlinPrinter : ASTCodeGenerator<KCompilationUnit>() {
 
     override val placeholderNodePrinter: NodePrinter
         get() = NodePrinter { output: PrinterOutput, ast: Node ->
-            val origin = (ast.origin as MissingASTTransformation).origin
+            val origin = (ast.origin as PlaceholderASTTransformation).origin
             val nodeType = if (origin is Node) {
                 origin.nodeType
             } else {

--- a/core/src/test/kotlin/com/strumenta/kolasu/ids/SourceIdProviderTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/ids/SourceIdProviderTest.kt
@@ -1,0 +1,15 @@
+package com.strumenta.kolasu.ids
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SourceIdProviderTest {
+
+    @Test
+    fun testRemoveCharactersInvalidInLionWebIDs() {
+        assertEquals(
+            "funny933--_12aaAAAAZz",
+            "funny%à, è, é, ì, ò, ù =+933--_12aaAAAAZz".removeCharactersInvalidInLionWebIDs()
+        )
+    }
+}

--- a/core/src/test/kotlin/com/strumenta/kolasu/mapping/ParseTreeToASTTransformerTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/mapping/ParseTreeToASTTransformerTest.kt
@@ -87,9 +87,17 @@ class ParseTreeToASTTransformerTest {
 
         val cu = CU(
             statements = listOf(
-                GenericErrorNode(message = "Exception java.lang.IllegalStateException: Parse error")
+                GenericErrorNode(
+                    message = "RuntimeException: Failed to transform [8] into " +
+                        "class com.strumenta.simplelang.SimpleLangParser${'$'}SetStmtContext " +
+                        "-> IllegalStateException: Parse error"
+                )
                     .withParseTreeNode(pt.statement(0)),
-                GenericErrorNode(message = "Exception java.lang.IllegalStateException: Parse error")
+                GenericErrorNode(
+                    message = "RuntimeException: Failed to transform [8] into " +
+                        "class com.strumenta.simplelang.SimpleLangParser${'$'}DisplayStmtContext " +
+                        "-> IllegalStateException: Parse error"
+                )
                     .withParseTreeNode(pt.statement(1))
             )
         ).withParseTreeNode(pt)

--- a/core/src/test/kotlin/com/strumenta/kolasu/transformation/DummyNodesTest.kt
+++ b/core/src/test/kotlin/com/strumenta/kolasu/transformation/DummyNodesTest.kt
@@ -1,0 +1,66 @@
+package com.strumenta.kolasu.transformation
+
+import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.PossiblyNamed
+import com.strumenta.kolasu.model.ReferenceByName
+import junit.framework.TestCase.assertEquals
+import kotlin.test.Test
+
+enum class SomeAlternatives {
+    BAR,
+    FOO,
+    ZUM
+}
+
+data class MyNodeWithProps(val p1: Int, val p2: Boolean, val p4: String) : Node()
+data class MyNodeWithLongProp(val p3: Long) : Node()
+data class MyNodeWithEnum(val p5: SomeAlternatives) : Node()
+data class MyNodeWithContainments(
+    val c1: MyNodeWithProps,
+    val c2: MyNodeWithProps?,
+    val c3: MutableList<MyNodeWithProps>
+) : Node()
+data class MyNodeWithRefs(val r1: ReferenceByName<PossiblyNamed>?, val r2: ReferenceByName<PossiblyNamed>) : Node()
+
+class DummyNodesTest {
+
+    @Test
+    fun canCreateDummyNodeWithProperties() {
+        val dummyNode = MyNodeWithProps::class.dummyInstance()
+        assert(dummyNode is MyNodeWithProps)
+        assertEquals(0, dummyNode.p1)
+        assertEquals(false, dummyNode.p2)
+        assertEquals("DUMMY", dummyNode.p4)
+    }
+
+    @Test
+    fun canCreateDummyNodeWithLongProp() {
+        val dummyNode = MyNodeWithLongProp::class.dummyInstance()
+        assert(dummyNode is MyNodeWithLongProp)
+        assertEquals(0L, dummyNode.p3)
+    }
+
+    @Test
+    fun canCreateDummyNodeWithEnum() {
+        val dummyNode = MyNodeWithEnum::class.dummyInstance()
+        assert(dummyNode is MyNodeWithEnum)
+        assertEquals(SomeAlternatives.BAR, dummyNode.p5)
+    }
+
+    @Test
+    fun canCreateDummyNodeWithContainments() {
+        val dummyNode = MyNodeWithContainments::class.dummyInstance()
+        assert(dummyNode is MyNodeWithContainments)
+        assert(dummyNode.c1 is MyNodeWithProps)
+        assertEquals(null, dummyNode.c2)
+        assertEquals(emptyList<MyNodeWithProps>(), dummyNode.c3)
+    }
+
+    @Test
+    fun canCreateDummyNodeWithRefs() {
+        val dummyNode = MyNodeWithRefs::class.dummyInstance()
+        assert(dummyNode is MyNodeWithRefs)
+        assertEquals(null, dummyNode.r1)
+        assertEquals(ReferenceByName<PossiblyNamed>("UNKNOWN"), dummyNode.r2)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,6 @@ gson_version=2.10.1
 lionwebJavaVersion=0.2.18
 kspVersion=1.0.11
 lionwebGenGradlePluginID=com.strumenta.kolasu.lionwebgen
-kotestVersion=1.3.3
 lionwebRepositoryCommitID=ce4949ab88e2407d75b531a1807fbd690e6dab1f
 SONATYPE_CONNECT_TIMEOUT_SECONDS=180
 SONATYPE_CLOSE_TIMEOUT_SECONDS=900

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,6 @@ lionwebJavaVersion=0.2.18
 kspVersion=1.0.11
 lionwebGenGradlePluginID=com.strumenta.kolasu.lionwebgen
 kotestVersion=1.3.3
-lionwebRepositoryCommitID=bf25f21d8baea6b7b7918febefc40ee4151f5088
+lionwebRepositoryCommitID=ce4949ab88e2407d75b531a1807fbd690e6dab1f
 SONATYPE_CONNECT_TIMEOUT_SECONDS=180
 SONATYPE_CLOSE_TIMEOUT_SECONDS=900

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ superPublish = { id = "com.vanniktech.maven.publish", version = "0.22.0" }
 
 [versions]
 lwjava = "0.2.19"
-lwkotlin = "0.2.5"
+lwkotlin = "0.2.6-SNAPSHOT"
 
 [libraries]
 lionwebjava = { group = "io.lionweb.lionweb-java", name = "lionweb-java-2023.1-core", version.ref = "lwjava" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,12 @@
 [plugins]
 buildConfig = { id = "com.github.gmazzo.buildconfig", version = "5.3.5" }
 superPublish = { id = "com.vanniktech.maven.publish", version = "0.22.0" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "11.5.1" }
 
 [versions]
 lwjava = "0.2.19"
-lwkotlin = "0.2.6-SNAPSHOT"
+lwkotlin = "0.2.6"
+kotestVersion= "1.3.3"
 
 [libraries]
 lionwebjava = { group = "io.lionweb.lionweb-java", name = "lionweb-java-2023.1-core", version.ref = "lwjava" }
@@ -12,3 +14,4 @@ lionwebjavaemf = { group = "io.lionweb.lionweb-java", name = "lionweb-java-2023.
 lionwebkotlinrepoclient = { group = "io.lionweb.lionweb-kotlin", name = "lionweb-kotlin-2024.1-repo-client", version.ref = "lwkotlin" }
 lionwebkotlinrepoclienttesting = { group = "io.lionweb.lionweb-kotlin", name = "lionweb-kotlin-2024.1-repo-client-testing", version.ref = "lwkotlin" }
 lionwebkotlincore = { group = "io.lionweb.lionweb-kotlin", name = "lionweb-kotlin-2024.1-core", version.ref = "lwkotlin" }
+kotesttestcontainers = { module = "io.kotest.extensions:kotest-extensions-testcontainers", version.ref = "kotestVersion" }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -59,6 +59,7 @@ import kotlin.reflect.KMutableProperty
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.primaryConstructor
 import io.lionweb.lioncore.java.language.Feature as LWFeature
+import com.strumenta.kolasu.transformation.PlaceholderASTTransformation
 
 interface PrimitiveValueSerialization<E> {
     fun serialize(value: E): String
@@ -218,7 +219,7 @@ class LionWebModelConverter(
                                 if (origin is KNode) {
                                     val targetID = myIDManager.nodeId(origin)
                                     setOriginalNode(lwNode, targetID)
-                                } else if (origin is MissingASTTransformation) {
+                                } else if (origin is PlaceholderASTTransformation) {
                                     if (lwNode is AbstractClassifierInstance<*>) {
                                         val instance = DynamicAnnotationInstance(
                                             StarLasuLWLanguage.PlaceholderNode.id,

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -22,6 +22,7 @@ import com.strumenta.kolasu.model.nodeOriginalProperties
 import com.strumenta.kolasu.parsing.FirstStageParsingResult
 import com.strumenta.kolasu.parsing.KolasuToken
 import com.strumenta.kolasu.parsing.ParsingResult
+import com.strumenta.kolasu.transformation.FailingASTTransformation
 import com.strumenta.kolasu.transformation.MissingASTTransformation
 import com.strumenta.kolasu.transformation.PlaceholderASTTransformation
 import com.strumenta.kolasu.traversing.walk
@@ -32,11 +33,13 @@ import io.lionweb.lioncore.java.language.Classifier
 import io.lionweb.lioncore.java.language.Concept
 import io.lionweb.lioncore.java.language.Containment
 import io.lionweb.lioncore.java.language.Enumeration
+import io.lionweb.lioncore.java.language.EnumerationLiteral
 import io.lionweb.lioncore.java.language.Language
 import io.lionweb.lioncore.java.language.LionCoreBuiltins
 import io.lionweb.lioncore.java.language.PrimitiveType
 import io.lionweb.lioncore.java.language.Property
 import io.lionweb.lioncore.java.language.Reference
+import io.lionweb.lioncore.java.model.AnnotationInstance
 import io.lionweb.lioncore.java.model.Node
 import io.lionweb.lioncore.java.model.ReferenceValue
 import io.lionweb.lioncore.java.model.impl.AbstractClassifierInstance
@@ -243,6 +246,7 @@ class LionWebModelConverter(
                                             val targetID = myIDManager.nodeId(origin.origin as KNode)
                                             setOriginalNode(lwNode, targetID)
                                         }
+                                        setPlaceholderNodeType(instance, origin.javaClass.kotlin)
                                         lwNode.addAnnotation(instance)
                                     } else {
                                         throw Exception(
@@ -354,6 +358,26 @@ class LionWebModelConverter(
             listOf(
                 ReferenceValue(ProxyNode(targetID), null)
             )
+        )
+    }
+
+    private fun setPlaceholderNodeType(
+        placeholderAnnotation: AnnotationInstance,
+        kClass: KClass<out PlaceholderASTTransformation>
+    ) {
+        val enumerationLiteral: EnumerationLiteral = when (kClass) {
+            MissingASTTransformation::class -> StarLasuLWLanguage.PlaceholderNodeType.literals.find {
+                it.name == "MissingASTTransformation"
+            }!!
+            FailingASTTransformation::class -> StarLasuLWLanguage.PlaceholderNodeType.literals.find {
+                it.name == "FailingASTTransformation"
+            }!!
+            else -> TODO()
+        }
+
+        placeholderAnnotation.setPropertyValue(
+            StarLasuLWLanguage.PlaceholderNodeTypeProperty,
+            EnumerationValueImpl(enumerationLiteral)
         )
     }
 

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -23,6 +23,7 @@ import com.strumenta.kolasu.parsing.FirstStageParsingResult
 import com.strumenta.kolasu.parsing.KolasuToken
 import com.strumenta.kolasu.parsing.ParsingResult
 import com.strumenta.kolasu.transformation.MissingASTTransformation
+import com.strumenta.kolasu.transformation.PlaceholderASTTransformation
 import com.strumenta.kolasu.traversing.walk
 import com.strumenta.kolasu.validation.Issue
 import com.strumenta.kolasu.validation.IssueSeverity
@@ -59,7 +60,6 @@ import kotlin.reflect.KMutableProperty
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.primaryConstructor
 import io.lionweb.lioncore.java.language.Feature as LWFeature
-import com.strumenta.kolasu.transformation.PlaceholderASTTransformation
 
 interface PrimitiveValueSerialization<E> {
     fun serialize(value: E): String
@@ -169,7 +169,9 @@ class LionWebModelConverter(
                 if (!nodesMapping.containsA(kNode)) {
                     val nodeID = myIDManager.nodeId(kNode)
                     if (!CommonChecks.isValidID(nodeID)) {
-                        throw RuntimeException("We generated an invalid Node ID, using $myIDManager in $kNode. Node ID: $nodeID")
+                        throw RuntimeException(
+                            "We generated an invalid Node ID, using $myIDManager in $kNode. Node ID: $nodeID"
+                        )
                     }
                     val lwNode = DynamicNode(nodeID, findConcept(kNode))
                     associateNodes(kNode, lwNode)
@@ -403,9 +405,13 @@ class LionWebModelConverter(
             }
         }
         referencesPostponer.populateReferences(nodesMapping, externalNodeResolver)
-        placeholderNodes.forEach { it.origin = MissingASTTransformation(origin = it.origin,
-            transformationSource = it.origin as com.strumenta.kolasu.model.Node,
-            expectedType = null) }
+        placeholderNodes.forEach {
+            it.origin = MissingASTTransformation(
+                origin = it.origin,
+                transformationSource = it.origin as com.strumenta.kolasu.model.Node,
+                expectedType = null
+            )
+        }
         return nodesMapping.byB(lwTree)!!
     }
 

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -152,8 +152,16 @@ class LionWebModelConverter(
             private val cache = IdentityHashMap<KNode, String>()
 
             fun nodeId(kNode: KNode): String {
-                return cache.getOrPut(kNode) { nodeIdProvider.id(kNode) }
+                return cache.getOrPut(kNode) {
+                    val id = nodeIdProvider.id(kNode)
+                    if (!CommonChecks.isValidID(id)) {
+                        throw RuntimeException("We got an invalid Node ID from $nodeIdProvider for $id")
+                    }
+                    id
+                }
             }
+
+            override fun toString(): String = "Caching ID Manager in front of $nodeIdProvider"
         }
 
         if (!nodesMapping.containsA(kolasuTree)) {
@@ -226,7 +234,7 @@ class LionWebModelConverter(
                                 } else if (origin is PlaceholderASTTransformation) {
                                     if (lwNode is AbstractClassifierInstance<*>) {
                                         val instance = DynamicAnnotationInstance(
-                                            StarLasuLWLanguage.PlaceholderNode.id,
+                                            "${lwNode.id}_placeholder_annotation",
                                             StarLasuLWLanguage.PlaceholderNode
                                         )
                                         if (origin.origin is KNode) {

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -159,7 +159,11 @@ class LionWebModelConverter(
         if (!nodesMapping.containsA(kolasuTree)) {
             kolasuTree.walk().forEach { kNode ->
                 if (!nodesMapping.containsA(kNode)) {
-                    val lwNode = DynamicNode(myIDManager.nodeId(kNode), findConcept(kNode))
+                    val nodeID = myIDManager.nodeId(kNode)
+                    if (!CommonChecks.isValidID(nodeID)) {
+                        throw RuntimeException("We generated an invalid Node ID, using $myIDManager in $kNode. Node ID: $nodeID")
+                    }
+                    val lwNode = DynamicNode(nodeID, findConcept(kNode))
                     associateNodes(kNode, lwNode)
                 }
             }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -391,7 +391,9 @@ class LionWebModelConverter(
             }
         }
         referencesPostponer.populateReferences(nodesMapping, externalNodeResolver)
-        placeholderNodes.forEach { it.origin = MissingASTTransformation(it.origin) }
+        placeholderNodes.forEach { it.origin = MissingASTTransformation(origin = it.origin,
+            transformationSource = it.origin as com.strumenta.kolasu.model.Node,
+            expectedType = null) }
         return nodesMapping.byB(lwTree)!!
     }
 

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebSource.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebSource.kt
@@ -2,7 +2,14 @@ package com.strumenta.kolasu.lionweb
 
 import com.strumenta.kolasu.model.Source
 import com.strumenta.kolasu.model.SourceWithID
+import io.lionweb.lioncore.java.utils.CommonChecks
 
 data class LionWebSource(val sourceId: String) : Source(), SourceWithID {
     override fun sourceID(): String = sourceId
+
+    init {
+        if (!CommonChecks.isValidID(sourceId)) {
+            throw IllegalArgumentException("Illegal SourceId provided")
+        }
+    }
 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
@@ -197,7 +197,9 @@ private fun registerSerializersAndDeserializersInMetamodelRegistry() {
             null
         } else {
             val parts = serialized.split("-")
-            require(parts.size == 2)
+            require(parts.size == 2) {
+                "Position has an expected format: $serialized"
+            }
             Position(pointDeserializer.deserialize(parts[0]), pointDeserializer.deserialize(parts[1]))
         }
     }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
@@ -10,6 +10,8 @@ import com.strumenta.kolasu.validation.IssueSeverity
 import com.strumenta.kolasu.validation.IssueType
 import io.lionweb.lioncore.java.language.Annotation
 import io.lionweb.lioncore.java.language.Concept
+import io.lionweb.lioncore.java.language.Enumeration
+import io.lionweb.lioncore.java.language.EnumerationLiteral
 import io.lionweb.lioncore.java.language.Interface
 import io.lionweb.lioncore.java.language.Language
 import io.lionweb.lioncore.java.language.LionCoreBuiltins
@@ -101,6 +103,29 @@ object StarLasuLWLanguage : Language("com.strumenta.StarLasu") {
             keyForContainedElement(PLACEHOLDER_NODE)
         )
         placeholderNodeAnnotation.annotates = LionCore.getConcept()
+
+        val placeholderNodeAnnotationType = Enumeration(
+            this,
+            "PlaceholderNodeType"
+        ).apply {
+            this.id = "${placeholderNodeAnnotation.id!!.removeSuffix("-id")}-$name-id"
+            this.key = "${placeholderNodeAnnotation.key!!.removeSuffix("-key")}-$name-key"
+            val enumeration = this
+            addLiteral(
+                EnumerationLiteral(this, "MissingASTTransformation").apply {
+                    this.id = "${enumeration.id!!.removeSuffix("-id")}-$name-id"
+                    this.key = "${enumeration.id!!.removeSuffix("-key")}-$name-key"
+                }
+            )
+            addLiteral(
+                EnumerationLiteral(this, "FailingASTTransformation").apply {
+                    this.id = "${enumeration.id!!.removeSuffix("-id")}-$name-id"
+                    this.key = "${enumeration.id!!.removeSuffix("-key")}-$name-key"
+                }
+            )
+        }
+        addElement(placeholderNodeAnnotationType)
+
         val reference =
             Reference().apply {
                 this.name = "originalNode"
@@ -111,6 +136,14 @@ object StarLasuLWLanguage : Language("com.strumenta.StarLasu") {
                 this.setMultiple(false)
             }
         placeholderNodeAnnotation.addFeature(reference)
+        val type = Property().apply {
+            this.name = "type"
+            this.id = "${placeholderNodeAnnotation.id!!.removeSuffix("-id")}-$name-id"
+            this.key = "${placeholderNodeAnnotation.key!!.removeSuffix("-key")}-$name-key"
+            this.type = placeholderNodeAnnotationType
+            this.setOptional(false)
+        }
+        placeholderNodeAnnotation.addFeature(type)
         addElement(placeholderNodeAnnotation)
     }
 
@@ -140,6 +173,12 @@ object StarLasuLWLanguage : Language("com.strumenta.StarLasu") {
 
     val PlaceholderNodeOriginalNode: Reference
         get() = PlaceholderNode.getReferenceByName("originalNode")!!
+
+    val PlaceholderNodeTypeProperty: Property
+        get() = PlaceholderNode.getPropertyByName("type")!!
+
+    val PlaceholderNodeType: Enumeration
+        get() = StarLasuLWLanguage.getEnumerationByName("PlaceholderNodeType")!!
 
     val BehaviorDeclaration: Interface
         get() = StarLasuLWLanguage.getInterfaceByName("BehaviorDeclaration")!!

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/StarLasuLWLanguage.kt
@@ -144,6 +144,14 @@ object StarLasuLWLanguage : Language("com.strumenta.StarLasu") {
             this.setOptional(false)
         }
         placeholderNodeAnnotation.addFeature(type)
+        val message = Property().apply {
+            this.name = "message"
+            this.id = "${placeholderNodeAnnotation.id!!.removeSuffix("-id")}-$name-id"
+            this.key = "${placeholderNodeAnnotation.key!!.removeSuffix("-key")}-$name-key"
+            this.type = LionCoreBuiltins.getString()
+            this.setOptional(false)
+        }
+        placeholderNodeAnnotation.addFeature(message)
         addElement(placeholderNodeAnnotation)
     }
 
@@ -176,6 +184,9 @@ object StarLasuLWLanguage : Language("com.strumenta.StarLasu") {
 
     val PlaceholderNodeTypeProperty: Property
         get() = PlaceholderNode.getPropertyByName("type")!!
+
+    val PlaceholderNodeMessageProperty: Property
+        get() = PlaceholderNode.getPropertyByName("message")!!
 
     val PlaceholderNodeType: Enumeration
         get() = StarLasuLWLanguage.getEnumerationByName("PlaceholderNodeType")!!

--- a/lionwebrepo-client/build.gradle.kts
+++ b/lionwebrepo-client/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     alias(libs.plugins.buildConfig)
 }
 
-val kotestVersion = extra["kotestVersion"]
 val kotlinVersion = extra["kotlin_version"]
 
 repositories {
@@ -32,7 +31,7 @@ testing {
                 implementation(libs.lionwebkotlinrepoclient)
                 implementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")
                 implementation("io.kotest:kotest-runner-junit5-jvm:5.8.0")
-                implementation("io.kotest.extensions:kotest-extensions-testcontainers:$kotestVersion")
+                implementation(libs.kotesttestcontainers)
                 implementation("io.kotest:kotest-assertions-core:5.8.0")
                 implementation("io.kotest:kotest-property:5.8.0")
                 implementation("org.testcontainers:testcontainers:1.19.5")

--- a/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
+++ b/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
@@ -18,6 +18,7 @@ import com.strumenta.kolasu.model.assignParents
 import com.strumenta.kolasu.traversing.walkDescendants
 import io.lionweb.lioncore.java.language.Concept
 import io.lionweb.lioncore.java.model.HasSettableParent
+import io.lionweb.lioncore.java.model.impl.ProxyNode
 import io.lionweb.lioncore.java.serialization.JsonSerialization
 import io.lionweb.lioncore.java.serialization.SerializationProvider
 import io.lionweb.lioncore.java.serialization.UnavailableNodePolicy
@@ -399,7 +400,11 @@ class KolasuClient(
         nodeID: String,
         withProxyParent: Boolean = false,
     ): LWNode {
-        return lionWebClient.retrieve(nodeID, withProxyParent, retrievalMode = RetrievalMode.SINGLE_NODE)
+        val result = lionWebClient.retrieve(nodeID, withProxyParent, retrievalMode = RetrievalMode.SINGLE_NODE)
+        require(result !is ProxyNode) {
+            "The LionWebClient should not retrieve a node as a ProxyNode"
+        }
+        return result
     }
 
     fun getShallowLionWebNodes(

--- a/playground/src/test/kotlin/com/strumenta/kolasu/playground/ParserTraceTest.kt
+++ b/playground/src/test/kotlin/com/strumenta/kolasu/playground/ParserTraceTest.kt
@@ -43,7 +43,7 @@ class ParserTraceTest {
     "eClass": "https://strumenta.com/starlasu/v2#//Result",
     "root": {
       "eClass": "https://strumenta.com/starlasu/v2#//GenericErrorNode",
-      "message": "Exception java.lang.Exception: foo"
+      "message": "Exception: foo"
     }
   }
 }""",

--- a/semantics/build.gradle.kts
+++ b/semantics/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     `maven-publish`
     idea
     signing
-    id("org.jlleitschuh.gradle.ktlint")
+    alias(libs.plugins.ktlint)
     id("org.jetbrains.dokka")
 }
 

--- a/semantics/src/main/kotlin/com/strumenta/kolasu/semantics/symbol/resolver/SymbolResolver.kt
+++ b/semantics/src/main/kotlin/com/strumenta/kolasu/semantics/symbol/resolver/SymbolResolver.kt
@@ -7,6 +7,7 @@ import com.strumenta.kolasu.model.children
 import com.strumenta.kolasu.model.kReferenceByNameType
 import com.strumenta.kolasu.model.nodeProperties
 import com.strumenta.kolasu.semantics.scope.provider.ScopeProvider
+import com.strumenta.kolasu.transformation.isDirectlyPlaceholderASTTransformation
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.isSubtypeOf
 
@@ -52,8 +53,15 @@ open class SymbolResolver(
         node: Node,
         entireTree: Boolean = false
     ) {
+        if (node.isDirectlyPlaceholderASTTransformation) {
+            return
+        }
         node.references().forEach { reference -> this.resolve(node, reference) }
-        if (entireTree) node.children.forEach { this.resolve(it, entireTree) }
+        if (entireTree) {
+            node.children.filter { !it.isDirectlyPlaceholderASTTransformation }.forEach {
+                this.resolve(it, entireTree)
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
When we implement transformers we may have the case in which the transformation is missing and the case in which it is failing. It may be failing because we cover a certain subset of cases. For example, when transforming from RPG to Java, we may cover a field declaration if the field is a string or a number, but not if it is of type pointer. In these cases we may want to still produce a partial transformation, treating the failure similarly to what we do with missing transformations. So expand the strategy for missing transformation to cover also failing transformations.

In addition to this:
* We ensure that generated IDs are compatible with LionWeb, removing illegal characters
* We expand the logic to instantiate a dummy node, with the sole purpose of attaching an origin to it. Previously we were needing a default constructor. Now, if that is not present, we attempt to use other constructors, generating dummy values as needed