### PR TITLE
Propagate expected type

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/mapping/Support.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/mapping/Support.kt
@@ -1,5 +1,6 @@
 package com.strumenta.kolasu.mapping
 
+import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.parsing.getOriginalText
 import com.strumenta.kolasu.transformation.ASTTransformer
 import org.antlr.v4.runtime.ParserRuleContext
@@ -29,8 +30,8 @@ fun <T> ASTTransformer.translateCasted(original: Any): T {
  * JExtendsType(translateCasted(pt.typeType()), translateList(pt.annotation()))
  * ```
  */
-fun <T> ASTTransformer.translateList(original: Collection<out Any>?): MutableList<T> {
-    return original?.map { transformIntoNodes(it) as List<T> }?.flatten()?.toMutableList() ?: mutableListOf()
+inline fun <reified T : Node> ASTTransformer.translateList(original: Collection<out Any>?): MutableList<T> {
+    return original?.map { transformIntoNodes(it, expectedType = T::class) as List<T> }?.flatten()?.toMutableList() ?: mutableListOf()
 }
 
 /**

--- a/core/src/main/kotlin/com/strumenta/kolasu/mapping/Support.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/mapping/Support.kt
@@ -13,8 +13,8 @@ import org.antlr.v4.runtime.ParserRuleContext
  * JPostIncrementExpr(translateCasted<JExpression>(expression().first()))
  * ```
  */
-fun <T> ASTTransformer.translateCasted(original: Any): T {
-    val result = transform(original)
+inline fun <reified T : Node> ASTTransformer.translateCasted(original: Any): T {
+    val result = transform(original, expectedType = T::class)
     if (result is Nothing) {
         throw IllegalStateException("Transformation produced Nothing")
     }
@@ -31,7 +31,8 @@ fun <T> ASTTransformer.translateCasted(original: Any): T {
  * ```
  */
 inline fun <reified T : Node> ASTTransformer.translateList(original: Collection<out Any>?): MutableList<T> {
-    return original?.map { transformIntoNodes(it, expectedType = T::class) as List<T> }?.flatten()?.toMutableList() ?: mutableListOf()
+    return original?.map { transformIntoNodes(it, expectedType = T::class) as List<T> }?.flatten()?.toMutableList()
+        ?: mutableListOf()
 }
 
 /**
@@ -47,8 +48,8 @@ inline fun <reified T : Node> ASTTransformer.translateList(original: Collection<
  *  )
  *  ```
  */
-fun <T> ASTTransformer.translateOptional(original: Any?): T? {
-    return original?.let { transform(it) as T }
+inline fun <reified T : Node> ASTTransformer.translateOptional(original: Any?): T? {
+    return original?.let { transform(it, expectedType = T::class) as T }
 }
 
 /**

--- a/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/transformation/Transformation.kt
@@ -272,8 +272,8 @@ open class ASTTransformer(
      * This ensures that the generated value is a single Node or null.
      */
     @JvmOverloads
-    fun transform(source: Any?, parent: Node? = null): Node? {
-        val result = transformIntoNodes(source, parent)
+    fun transform(source: Any?, parent: Node? = null, expectedType: KClass<out Node> = Node::class): Node? {
+        val result = transformIntoNodes(source, parent, expectedType)
         return when (result.size) {
             0 -> null
             1 -> {


### PR DESCRIPTION
There are circumstances in which we use the expected type to instantiate dummy nodes. For this to work we need to propagate the expected type in different circumstances.