### PR TITLE
Consider only original properties in Node.toString

### DIFF
--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
@@ -189,7 +189,7 @@ open class Node() : Origin, Destination, Serializable {
      * of circular graphs.
      */
     final override fun toString(): String {
-        return "${this.nodeType}(${properties.joinToString(", ") { "${it.name}=${it.valueToString()}" }})"
+        return "${this.nodeType}(${originalProperties.joinToString(", ") { "${it.name}=${it.valueToString()}" }})"
     }
 
     fun getChildren(containment: Containment, includeDerived: Boolean = false): List<Node> {


### PR DESCRIPTION
We should not try to print also derived properties as they could lead to redundant information being printed, and possible circular structures (leading to stack overflows).