### PR TITLE
Update LionWeb dependencies

### DIFF
--- a/codebase/build.gradle.kts
+++ b/codebase/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
 
 val jvmVersion = project.property("jvm_version") as String
 val kotlinVersion = project.property("kotlin_version") as String
-val gsonVersion = project.property("gson_version") as String
 
 val isReleaseVersion = !(project.version as String).endsWith("-SNAPSHOT")
 
@@ -28,7 +27,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
-    implementation("com.google.code.gson:gson:$gsonVersion")
+    implementation(libs.gson)
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
 }
 

--- a/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/CodebaseAdapters.kt
+++ b/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/CodebaseAdapters.kt
@@ -1,7 +1,6 @@
 package com.strumenta.kolasu.codebase
 
 import com.strumenta.kolasu.lionweb.IssueNode
-import com.strumenta.kolasu.lionweb.LIONWEB_VERSION_USED_BY_KOLASU
 import com.strumenta.kolasu.lionweb.LWNode
 import com.strumenta.kolasu.lionweb.LionWebModelConverter
 import com.strumenta.kolasu.model.Node
@@ -10,14 +9,11 @@ import com.strumenta.starlasu.base.CodebaseLanguage
 import io.lionweb.lioncore.java.model.ClassifierInstanceUtils
 import io.lionweb.lioncore.java.model.impl.DynamicNode
 import io.lionweb.lioncore.java.serialization.JsonSerialization
-import io.lionweb.lioncore.java.serialization.SerializationProvider
-import io.lionweb.lioncore.kotlin.MetamodelRegistry
 import io.lionweb.lioncore.kotlin.getChildrenByContainmentName
 import io.lionweb.lioncore.kotlin.getOnlyChildByContainmentName
 import io.lionweb.lioncore.kotlin.getPropertyValueByName
 import io.lionweb.lioncore.kotlin.setPropertyValueByName
 import java.util.stream.Collectors
-import javax.json.spi.JsonProvider
 
 fun <R : Node> deserialize(
     modelConverter: LionWebModelConverter,
@@ -61,14 +57,13 @@ fun <R : Node> convertCodebase(
     languagesWeConsider: Set<String>,
     jsonSerialization: JsonSerialization
 ): Codebase<R> {
-
     return object : Codebase<R> {
         override val name: String
             get() = codebaseAccess.name
 
         private val filesCache: List<CodebaseFile<R>> by lazy {
             codebaseAccess.files().map { fileIdentifier ->
-               val serializedFile = codebaseAccess.retrieveFile(fileIdentifier)
+                val serializedFile = codebaseAccess.retrieveFile(fileIdentifier)
                 jsonSerialization.deserializeToNodes(serializedFile)[0]
             }.filter { serializedCodebaseFile ->
                 val languageName = serializedCodebaseFile!!.getPropertyValueByName("language_name") as String

--- a/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/CodebaseAdapters.kt
+++ b/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/CodebaseAdapters.kt
@@ -1,6 +1,7 @@
 package com.strumenta.kolasu.codebase
 
 import com.strumenta.kolasu.lionweb.IssueNode
+import com.strumenta.kolasu.lionweb.LIONWEB_VERSION_USED_BY_KOLASU
 import com.strumenta.kolasu.lionweb.LWNode
 import com.strumenta.kolasu.lionweb.LionWebModelConverter
 import com.strumenta.kolasu.model.Node
@@ -8,11 +9,15 @@ import com.strumenta.starlasu.base.CodebaseAccess
 import com.strumenta.starlasu.base.CodebaseLanguage
 import io.lionweb.lioncore.java.model.ClassifierInstanceUtils
 import io.lionweb.lioncore.java.model.impl.DynamicNode
+import io.lionweb.lioncore.java.serialization.JsonSerialization
+import io.lionweb.lioncore.java.serialization.SerializationProvider
+import io.lionweb.lioncore.kotlin.MetamodelRegistry
 import io.lionweb.lioncore.kotlin.getChildrenByContainmentName
 import io.lionweb.lioncore.kotlin.getOnlyChildByContainmentName
 import io.lionweb.lioncore.kotlin.getPropertyValueByName
 import io.lionweb.lioncore.kotlin.setPropertyValueByName
 import java.util.stream.Collectors
+import javax.json.spi.JsonProvider
 
 fun <R : Node> deserialize(
     modelConverter: LionWebModelConverter,
@@ -53,15 +58,18 @@ fun <R : Node> serialize(
 fun <R : Node> convertCodebase(
     modelConverter: LionWebModelConverter,
     codebaseAccess: CodebaseAccess,
-    languagesWeConsider: Set<String>
+    languagesWeConsider: Set<String>,
+    jsonSerialization: JsonSerialization
 ): Codebase<R> {
+
     return object : Codebase<R> {
         override val name: String
             get() = codebaseAccess.name
 
         private val filesCache: List<CodebaseFile<R>> by lazy {
             codebaseAccess.files().map { fileIdentifier ->
-                codebaseAccess.retrieveFile(fileIdentifier)
+               val serializedFile = codebaseAccess.retrieveFile(fileIdentifier)
+                jsonSerialization.deserializeToNodes(serializedFile)[0]
             }.filter { serializedCodebaseFile ->
                 val languageName = serializedCodebaseFile!!.getPropertyValueByName("language_name") as String
                 languagesWeConsider.contains(languageName)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -25,12 +25,10 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     implementation 'org.redundent:kotlin-xml-builder:1.7.3'
     implementation("com.github.doyaaaaaken:kotlin-csv-jvm:1.9.2")
-    implementation "com.google.code.gson:gson:$gson_version"
+    implementation(libs.gson)
     api(libs.lionwebjava)
 
     api "com.github.ajalt.clikt:clikt:$clikt_version"
-
-    implementation("com.google.code.gson:gson:$gson_version")
 
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 }

--- a/emf/build.gradle
+++ b/emf/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     api group: 'org.eclipse.emf', name: 'org.eclipse.emf.ecore.xmi', version: '2.16.0'
     api group: 'org.eclipse.emfcloud', name: 'emfjson-jackson', version: '2.0.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
-    implementation "com.google.code.gson:gson:$gson_version"
+    implementation(libs.gson)
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: "$kotlin_version"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ lwjava = "0.4.4"
 lwkotlin = "0.4.1"
 kotestVersion= "1.3.3"
 specsVersion = "0.1.7"
+gson = "2.13.0"
 
 [plugins]
 buildConfig = { id = "com.github.gmazzo.buildconfig", version = "5.4.0" }
@@ -11,17 +12,12 @@ buildConfig = { id = "com.github.gmazzo.buildconfig", version = "5.4.0" }
 # We should configure JVM 11 for the build and JVM 8 only as a target
 superPublish = { id = "com.vanniktech.maven.publish", version = "0.22.0" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "11.5.1" }
-gradlePublish = { id = "com.gradle.plugin-publish", version = "1.2.1" }
-kover = { id = "org.jetbrains.kotlinx.kover", version = "0.8.3" }
 
 [libraries]
 lionwebjava = { group = "io.lionweb.lionweb-java", name = "lionweb-java-2024.1-core", version.ref = "lwjava" }
 lionwebjavaemf = { group = "io.lionweb.lionweb-java", name = "lionweb-java-2024.1-emf", version.ref = "lwjava" }
 lionwebjavarepoclienttesting = { group = "io.lionweb.lionweb-java", name = "lionweb-java-2024.1-repo-client-testing", version.ref = "lwjava" }
-gson = { module = "com.google.code.gson:gson", version = "2.11.0" }
-antlr4Tool = { module = "org.antlr:antlr4", version.ref = "antlr4" }
-antlr4jRuntime = { module = "org.antlr:antlr4-runtime", version.ref= "antlr4" }
-clikt = { module = "com.github.ajalt.clikt:clikt", version="4.4.0"}
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 lionwebkotlinrepoclient = { group = "io.lionweb.lionweb-kotlin", name = "lionweb-kotlin-2024.1-repo-client", version.ref = "lwkotlin" }
 lionwebkotlincore = { group = "io.lionweb.lionweb-kotlin", name = "lionweb-kotlin-2024.1-core", version.ref = "lwkotlin" }
 kotesttestcontainers = { module = "io.kotest.extensions:kotest-extensions-testcontainers", version.ref = "kotestVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 lwjava = "0.4.4"
 lwkotlin = "0.4.1"
 kotestVersion= "1.3.3"
-specsVersion = "0.1.7"
+specsVersion = "0.2.0-SNAPSHOT"
 gson = "2.13.0"
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 antlr4 = "4.9.3"
 lwjava = "0.4.4"
 lwkotlin = "0.4.1"
-kotestVersion= "2.0.2"
-specsVersion = "0.1.8"
+kotestVersion= "1.3.4"
+specsVersion = "0.1.7"
 
 [plugins]
 buildConfig = { id = "com.github.gmazzo.buildconfig", version = "5.4.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,12 +17,12 @@ kover = { id = "org.jetbrains.kotlinx.kover", version = "0.8.3" }
 [libraries]
 lionwebjava = { group = "io.lionweb.lionweb-java", name = "lionweb-java-2024.1-core", version.ref = "lwjava" }
 lionwebjavaemf = { group = "io.lionweb.lionweb-java", name = "lionweb-java-2024.1-emf", version.ref = "lwjava" }
+lionwebjavarepoclienttesting = { group = "io.lionweb.lionweb-java", name = "lionweb-java-2024.1-repo-client-testing", version.ref = "lwjava" }
 gson = { module = "com.google.code.gson:gson", version = "2.11.0" }
 antlr4Tool = { module = "org.antlr:antlr4", version.ref = "antlr4" }
 antlr4jRuntime = { module = "org.antlr:antlr4-runtime", version.ref= "antlr4" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version="4.4.0"}
 lionwebkotlinrepoclient = { group = "io.lionweb.lionweb-kotlin", name = "lionweb-kotlin-2024.1-repo-client", version.ref = "lwkotlin" }
-lionwebkotlinrepoclienttesting = { group = "io.lionweb.lionweb-kotlin", name = "lionweb-kotlin-2024.1-repo-client-testing", version.ref = "lwkotlin" }
 lionwebkotlincore = { group = "io.lionweb.lionweb-kotlin", name = "lionweb-kotlin-2024.1-core", version.ref = "lwkotlin" }
 kotesttestcontainers = { module = "io.kotest.extensions:kotest-extensions-testcontainers", version.ref = "kotestVersion" }
 starlasu-specs = { module="com.strumenta.starlasu.specs:starlasuspecs-jvm", version.ref="specsVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,26 @@
-[plugins]
-buildConfig = { id = "com.github.gmazzo.buildconfig", version = "5.3.5" }
-superPublish = { id = "com.vanniktech.maven.publish", version = "0.22.0" }
-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "11.5.1" }
-
 [versions]
-lwjava = "0.4.0"
-lwkotlin = "0.3.7"
+antlr4 = "4.9.3"
+lwjava = "0.4.3"
+lwkotlin = "0.4.1-SNAPSHOT"
 kotestVersion= "1.3.3"
 specsVersion = "0.1.7"
+
+[plugins]
+buildConfig = { id = "com.github.gmazzo.buildconfig", version = "5.4.0" }
+# More recent versions og this plugin to do not work with JVM 8
+# We should configure JVM 11 for the build and JVM 8 only as a target
+superPublish = { id = "com.vanniktech.maven.publish", version = "0.22.0" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "12.1.2" }
+gradlePublish = { id = "com.gradle.plugin-publish", version = "1.2.1" }
+kover = { id = "org.jetbrains.kotlinx.kover", version = "0.8.3" }
 
 [libraries]
 lionwebjava = { group = "io.lionweb.lionweb-java", name = "lionweb-java-2024.1-core", version.ref = "lwjava" }
 lionwebjavaemf = { group = "io.lionweb.lionweb-java", name = "lionweb-java-2024.1-emf", version.ref = "lwjava" }
+gson = { module = "com.google.code.gson:gson", version = "2.11.0" }
+antlr4Tool = { module = "org.antlr:antlr4", version.ref = "antlr4" }
+antlr4jRuntime = { module = "org.antlr:antlr4-runtime", version.ref= "antlr4" }
+clikt = { module = "com.github.ajalt.clikt:clikt", version="4.4.0"}
 lionwebkotlinrepoclient = { group = "io.lionweb.lionweb-kotlin", name = "lionweb-kotlin-2024.1-repo-client", version.ref = "lwkotlin" }
 lionwebkotlinrepoclienttesting = { group = "io.lionweb.lionweb-kotlin", name = "lionweb-kotlin-2024.1-repo-client-testing", version.ref = "lwkotlin" }
 lionwebkotlincore = { group = "io.lionweb.lionweb-kotlin", name = "lionweb-kotlin-2024.1-core", version.ref = "lwkotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 antlr4 = "4.9.3"
-lwjava = "0.4.3"
+lwjava = "0.4.4-SNAPSHOT"
 lwkotlin = "0.4.1-SNAPSHOT"
 kotestVersion= "1.3.3"
 specsVersion = "0.1.7"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 lwjava = "0.4.4"
-lwkotlin = "0.4.2-SNAPSHOT"
+lwkotlin = "0.4.2"
 kotestVersion= "1.3.3"
-specsVersion = "0.2.0-SNAPSHOT"
+specsVersion = "0.2.0"
 gson = "2.13.0"
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 antlr4 = "4.9.3"
-lwjava = "0.4.4-SNAPSHOT"
-lwkotlin = "0.4.1-SNAPSHOT"
-kotestVersion= "1.3.3"
+lwjava = "0.4.4"
+lwkotlin = "0.4.1"
+kotestVersion= "2.0.2"
 specsVersion = "0.1.7"
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ antlr4 = "4.9.3"
 lwjava = "0.4.4"
 lwkotlin = "0.4.1"
 kotestVersion= "2.0.2"
-specsVersion = "0.1.7"
+specsVersion = "0.1.8"
 
 [plugins]
 buildConfig = { id = "com.github.gmazzo.buildconfig", version = "5.4.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 antlr4 = "4.9.3"
 lwjava = "0.4.4"
 lwkotlin = "0.4.1"
-kotestVersion= "1.3.4"
+kotestVersion= "1.3.3"
 specsVersion = "0.1.7"
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ buildConfig = { id = "com.github.gmazzo.buildconfig", version = "5.4.0" }
 # More recent versions og this plugin to do not work with JVM 8
 # We should configure JVM 11 for the build and JVM 8 only as a target
 superPublish = { id = "com.vanniktech.maven.publish", version = "0.22.0" }
-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "12.1.2" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "11.5.1" }
 gradlePublish = { id = "com.gradle.plugin-publish", version = "1.2.1" }
 kover = { id = "org.jetbrains.kotlinx.kover", version = "0.8.3" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-antlr4 = "4.9.3"
 lwjava = "0.4.4"
 lwkotlin = "0.4.1"
 kotestVersion= "1.3.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 lwjava = "0.4.4"
-lwkotlin = "0.4.1"
+lwkotlin = "0.4.2-SNAPSHOT"
 kotestVersion= "1.3.3"
 specsVersion = "0.2.0-SNAPSHOT"
 gson = "2.13.0"

--- a/lionweb-gen-gradle/build.gradle.kts
+++ b/lionweb-gen-gradle/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
 
 val kspVersion = extra["kspVersion"] as String
 val kotlin_version = extra["kotlin_version"] as String
-val gson_version = extra["gson_version"] as String
 val lionwebGenGradlePluginID = extra["lionwebGenGradlePluginID"] as String
 val completeKspVersion = if (kspVersion.contains("-")) kspVersion else "${kotlin_version}-${kspVersion}"
 val lionwebJavaVersion = libs.lionwebjava.get().version
@@ -24,7 +23,7 @@ dependencies {
     testImplementation(project(":lionweb-ksp"))
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlin_version")
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
-    implementation("com.google.code.gson:gson:$gson_version")
+    implementation(libs.gson)
     implementation(libs.starlasu.specs)
     implementation("com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:$completeKspVersion")
 }

--- a/lionweb-gen/build.gradle
+++ b/lionweb-gen/build.gradle
@@ -30,7 +30,11 @@ dependencies {
 
     implementation("com.squareup:kotlinpoet:1.14.2")
     cliImplementation "com.github.ajalt.clikt:clikt:$clikt_version"
-    implementation(libs.gson)
+    implementation(libs.gson) {
+        version {
+            strictly(libs.versions.gson.get())
+        }
+    }
 
     // We use the embeddable version because it avoids issues with conflicting versions of dependencies
     // that we have when using the normal one
@@ -109,6 +113,14 @@ signing {
 
 test {
     useJUnitPlatform()
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency { details ->
+        if (details.requested.group == 'com.google.code.gson') {
+            details.useVersion(libs.versions.gson.get())
+        }
+    }
 }
 
 tasks.findByName("dokkaJavadoc").dependsOn(":core:compileKotlin")

--- a/lionweb-gen/build.gradle
+++ b/lionweb-gen/build.gradle
@@ -28,14 +28,9 @@ dependencies {
     api(project(":emf"))
     api(project(":lionweb"))
 
-
     implementation("com.squareup:kotlinpoet:1.14.2")
     cliImplementation "com.github.ajalt.clikt:clikt:$clikt_version"
-    implementation("com.google.code.gson:gson:$gson_version") {
-        version {
-            strictly gson_version
-        }
-    }
+    implementation(libs.gson)
 
     // We use the embeddable version because it avoids issues with conflicting versions of dependencies
     // that we have when using the normal one
@@ -114,14 +109,6 @@ signing {
 
 test {
     useJUnitPlatform()
-}
-
-configurations.all {
-    resolutionStrategy.eachDependency { details ->
-        if (details.requested.group == 'com.google.code.gson') {
-            details.useVersion gson_version
-        }
-    }
 }
 
 tasks.findByName("dokkaJavadoc").dependsOn(":core:compileKotlin")

--- a/lionweb/build.gradle
+++ b/lionweb/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     cliImplementation "com.github.ajalt.clikt:clikt:$clikt_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
-    testImplementation "com.google.code.gson:gson:$gson_version"
+    testImplementation(libs.gson)
     api(libs.lionwebjava)
     api(libs.lionwebkotlincore) {
         exclude group: "org.jetbrains.kotlin", module: "kotlin-test-junit5"

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -6,7 +6,6 @@ import com.strumenta.kolasu.language.Feature
 import com.strumenta.kolasu.language.KolasuLanguage
 import com.strumenta.kolasu.model.CompositeDestination
 import com.strumenta.kolasu.model.Multiplicity
-import com.strumenta.kolasu.model.Point
 import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.model.PossiblyNamed
 import com.strumenta.kolasu.model.ReferenceByName
@@ -436,7 +435,7 @@ class LionWebModelConverter(
             if (kNode is KNode) {
                 val lwPosition = lwNode.getPropertyValue(ASTNodePosition)
                 if (lwPosition != null) {
-                    kNode.position = lwPosition.asPosition()
+                    kNode.position = lwPosition as Position
                 }
                 val originalNodes = lwNode.getReferenceValues(ASTNodeOriginalNode)
                 if (originalNodes.isNotEmpty()) {
@@ -640,7 +639,7 @@ class LionWebModelConverter(
         }
     }
 
-    fun importEnumValue(propValue: EnumerationValue): Any {
+    private fun importEnumValue(propValue: EnumerationValue): Any {
         val enumerationLiteral = propValue.enumerationLiteral
         val enumKClass = synchronized(languageConverter) {
             languageConverter
@@ -763,7 +762,8 @@ class LionWebModelConverter(
                         val value = attributeValue(data, feature)
                         if (!param.type.isAssignableBy(value)) {
                             throw RuntimeException(
-                                "Cannot assign value $value (${value?.javaClass?.canonicalName}) to param ${param.name} of type ${param.type}"
+                                "Cannot assign value $value (${value?.javaClass?.canonicalName}) to param " +
+                                    "${param.name} of type ${param.type}"
                             )
                         }
                         params[param] = value
@@ -926,7 +926,7 @@ class LionWebModelConverter(
         ) as IssueSeverity
         val position = issueNode.getPropertyValue(
             ASTLanguage.getIssue().getPropertyByName(Issue::position.name)!!
-        )?.asPosition()
+        ) as Position
         val issue = Issue(issueType, message, severity, position)
         return issueNode.id!! to issue
     }
@@ -984,37 +984,4 @@ fun <T> Iterable<T>.myReversed(): List<T> {
     }
     result.reverse()
     return result
-}
-
-
-fun Any.asPosition(): Position {
-    if (this is Position) {
-        return this
-    }
-    // We have a version of Position obtained from another classloader.
-    // In the future Position should be moved to Specs and avoiding this, but in the meantime we convert
-    // to the version of Position that works here
-    if (this.javaClass.canonicalName == Position::class.qualifiedName) {
-        val start = this.javaClass.getMethod("getStart").invoke(this)!!.asPoint()
-        val end = this.javaClass.getMethod("getEnd").invoke(this)!!.asPoint()
-        return Position(start, end)
-    } else {
-        throw IllegalArgumentException()
-    }
-}
-
-fun Any.asPoint(): Point {
-    if (this is Point) {
-        return this
-    }
-    // We have a version of Position obtained from another classloader.
-    // In the future Position should be moved to Specs and avoiding this, but in the meantime we convert
-    // to the version of Position that works here
-    if (this.javaClass.canonicalName == Point::class.qualifiedName) {
-        val line = this.javaClass.getMethod("getLine").invoke(this) as Int
-        val column = this.javaClass.getMethod("getColumn").invoke(this) as Int
-        return Point(line, column)
-    } else {
-        throw IllegalArgumentException()
-    }
 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/PrimitiveSerialization.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/PrimitiveSerialization.kt
@@ -9,38 +9,13 @@ import io.lionweb.lioncore.java.serialization.PrimitiveValuesSerialization.Primi
 import io.lionweb.lioncore.kotlin.MetamodelRegistry
 
 fun registerSerializersAndDeserializersInMetamodelRegistry() {
-    val charSerializer = PrimitiveSerializer<Char> { value -> "$value" }
-    val charDeserializer = PrimitiveDeserializer<Char> { serialized ->
-        require(serialized.length == 1)
-        serialized[0]
-    }
     MetamodelRegistry.addSerializerAndDeserializer(StarLasuLWLanguage.Char, charSerializer, charDeserializer)
-
-    val pointSerializer: PrimitiveSerializer<Point> =
-        PrimitiveSerializer<Point> { value ->
-            if (value == null) {
-                return@PrimitiveSerializer null
-            }
-            "L${value.line}:${value.column}"
-        }
-
     MetamodelRegistry.addSerializerAndDeserializer(StarLasuLWLanguage.Point, pointSerializer, pointDeserializer)
-
-    val positionSerializer = PrimitiveSerializer<Position> { value ->
-        "${pointSerializer.serialize((value as Position).start)}-${pointSerializer.serialize(value.end)}"
-    }
-
     MetamodelRegistry.addSerializerAndDeserializer(
         StarLasuLWLanguage.Position,
         positionSerializer,
         positionDeserializer
     )
-
-    val tokensListPrimitiveSerializer = PrimitiveSerializer<TokensList?> { value: TokensList? ->
-        value?.tokens?.joinToString(";") { kt ->
-            kt.category.type + "$" + positionSerializer.serialize(kt.position)
-        }
-    }
 
     val tlpt = MetamodelRegistry.getPrimitiveType(TokensList::class, LIONWEB_VERSION_USED_BY_KOLASU)
         ?: throw IllegalStateException("Unknown primitive type class ${TokensList::class}")
@@ -89,5 +64,29 @@ val tokensListPrimitiveDeserializer = PrimitiveDeserializer<TokensList?> { seria
             }.toMutableList()
         }
         TokensList(tokens)
+    }
+}
+
+val charSerializer = PrimitiveSerializer<Char> { value -> "$value" }
+val charDeserializer = PrimitiveDeserializer<Char> { serialized ->
+    require(serialized.length == 1)
+    serialized[0]
+}
+
+val pointSerializer: PrimitiveSerializer<Point> =
+    PrimitiveSerializer<Point> { value ->
+        if (value == null) {
+            return@PrimitiveSerializer null
+        }
+        "L${value.line}:${value.column}"
+    }
+
+val positionSerializer = PrimitiveSerializer<Position> { value ->
+    "${pointSerializer.serialize((value as Position).start)}-${pointSerializer.serialize(value.end)}"
+}
+
+val tokensListPrimitiveSerializer = PrimitiveSerializer<TokensList?> { value: TokensList? ->
+    value?.tokens?.joinToString(";") { kt ->
+        kt.category.type + "$" + positionSerializer.serialize(kt.position)
     }
 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/PrimitiveSerialization.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/PrimitiveSerialization.kt
@@ -24,6 +24,28 @@ fun registerSerializersAndDeserializersInMetamodelRegistry() {
 
 class TokensList(val tokens: List<KolasuToken>)
 
+//
+// Char
+//
+
+val charSerializer = PrimitiveSerializer<Char> { value -> "$value" }
+val charDeserializer = PrimitiveDeserializer<Char> { serialized ->
+    require(serialized.length == 1)
+    serialized[0]
+}
+
+//
+// Point
+//
+
+val pointSerializer: PrimitiveSerializer<Point> =
+    PrimitiveSerializer<Point> { value ->
+        if (value == null) {
+            return@PrimitiveSerializer null
+        }
+        "L${value.line}:${value.column}"
+    }
+
 val pointDeserializer: PrimitiveDeserializer<Point> =
     PrimitiveDeserializer<Point> { serialized ->
         if (serialized == null) {
@@ -36,6 +58,14 @@ val pointDeserializer: PrimitiveDeserializer<Point> =
         Point(parts[0].toInt(), parts[1].toInt())
     }
 
+//
+// Position
+//
+
+val positionSerializer = PrimitiveSerializer<Position> { value ->
+    "${pointSerializer.serialize((value as Position).start)}-${pointSerializer.serialize(value.end)}"
+}
+
 val positionDeserializer = PrimitiveDeserializer<Position> { serialized ->
     if (serialized == null) {
         null
@@ -45,6 +75,16 @@ val positionDeserializer = PrimitiveDeserializer<Position> { serialized ->
             "Position has an expected format: $serialized"
         }
         Position(pointDeserializer.deserialize(parts[0]), pointDeserializer.deserialize(parts[1]))
+    }
+}
+
+//
+// Tokens List
+//
+
+val tokensListPrimitiveSerializer = PrimitiveSerializer<TokensList?> { value: TokensList? ->
+    value?.tokens?.joinToString(";") { kt ->
+        kt.category.type + "$" + positionSerializer.serialize(kt.position)
     }
 }
 
@@ -64,29 +104,5 @@ val tokensListPrimitiveDeserializer = PrimitiveDeserializer<TokensList?> { seria
             }.toMutableList()
         }
         TokensList(tokens)
-    }
-}
-
-val charSerializer = PrimitiveSerializer<Char> { value -> "$value" }
-val charDeserializer = PrimitiveDeserializer<Char> { serialized ->
-    require(serialized.length == 1)
-    serialized[0]
-}
-
-val pointSerializer: PrimitiveSerializer<Point> =
-    PrimitiveSerializer<Point> { value ->
-        if (value == null) {
-            return@PrimitiveSerializer null
-        }
-        "L${value.line}:${value.column}"
-    }
-
-val positionSerializer = PrimitiveSerializer<Position> { value ->
-    "${pointSerializer.serialize((value as Position).start)}-${pointSerializer.serialize(value.end)}"
-}
-
-val tokensListPrimitiveSerializer = PrimitiveSerializer<TokensList?> { value: TokensList? ->
-    value?.tokens?.joinToString(";") { kt ->
-        kt.category.type + "$" + positionSerializer.serialize(kt.position)
     }
 }

--- a/lionwebrepo-client/build.gradle.kts
+++ b/lionwebrepo-client/build.gradle.kts
@@ -37,7 +37,7 @@ testing {
                 implementation("org.testcontainers:testcontainers:1.19.5")
                 implementation("org.testcontainers:junit-jupiter:1.19.5")
                 implementation("org.testcontainers:postgresql:1.19.5")
-                implementation(libs.lionwebkotlinrepoclienttesting)
+                implementation(libs.lionwebjavarepoclienttesting)
             }
 
             targets {

--- a/lionwebrepo-client/src/functionalTest/kotlin/com/strumenta/kolasu/lionwebclient/TodoFunctionalTest.kt
+++ b/lionwebrepo-client/src/functionalTest/kotlin/com/strumenta/kolasu/lionwebclient/TodoFunctionalTest.kt
@@ -1,35 +1,42 @@
 package com.strumenta.kolasu.lionwebclient
 
 import com.strumenta.kolasu.lionweb.LIONWEB_VERSION_USED_BY_KOLASU
+import com.strumenta.kolasu.lionweb.registerSerializersAndDeserializersInMetamodelRegistry
 import com.strumenta.kolasu.model.ReferenceByName
 import com.strumenta.kolasu.model.SyntheticSource
 import com.strumenta.kolasu.model.assignParents
+import io.lionweb.lioncore.kotlin.MetamodelRegistry
 import io.lionweb.lioncore.kotlin.getChildrenByContainmentName
-import io.lionweb.lioncore.kotlin.repoclient.testing.AbstractRepoClientFunctionalTest
+import io.lionweb.repoclient.testing.AbstractRepoClientFunctionalTest
 import org.testcontainers.junit.jupiter.Testcontainers
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @Testcontainers
-class TodoFunctionalTest : AbstractRepoClientFunctionalTest(lionWebVersion = LIONWEB_VERSION_USED_BY_KOLASU) {
+class TodoFunctionalTest : AbstractRepoClientFunctionalTest(LIONWEB_VERSION_USED_BY_KOLASU, true) {
     @Test
     fun noPartitionsOnNewModelRepository() {
-        val kolasuClient = KolasuClient(port = modelRepository!!.firstMappedPort)
+        val kolasuClient = KolasuClient(port = modelRepository!!.firstMappedPort, repository = "repo_noPartitionsOnNewModelRepository")
+        kolasuClient.createRepository()
         assertEquals(emptyList(), kolasuClient.getPartitionIDs())
     }
 
     @Test
     fun storePartitionAndGetItBack() {
-        val kolasuClient = KolasuClient(port = modelRepository!!.firstMappedPort, debug = true)
+        val kolasuClient = KolasuClient(port = modelRepository!!.firstMappedPort, debug = true,
+            repository = "repo_storePartitionAndGetItBack")
+        kolasuClient.createRepository()
         kolasuClient.registerLanguage(todoLanguage)
         kolasuClient.registerLanguage(todoAccountLanguage)
+        registerSerializersAndDeserializersInMetamodelRegistry()
+        MetamodelRegistry.prepareJsonSerialization(kolasuClient.jsonSerialization)
 
         assertEquals(emptyList(), kolasuClient.getPartitionIDs())
 
         // We create an empty partition
         val todoAccount = TodoAccount("my-wonderful-partition")
         val expectedPartitionId = todoAccount.id!!
-        // By default the partition IDs are derived from the source
+        // By default, the partition IDs are derived from the source
         // todoAccount.source = SyntheticSource("my-wonderful-partition")
         kolasuClient.createPartition(todoAccount)
 
@@ -49,14 +56,16 @@ class TodoFunctionalTest : AbstractRepoClientFunctionalTest(lionWebVersion = LIO
         // todoProject.assignParents()
 
         todoProject.source = SyntheticSource("TODO Project A")
-        val todoProjectID = kolasuClient.attachAST(todoProject, containerID = expectedPartitionId, containmentName = "projects")
+        val todoProjectID = kolasuClient.attachAST(todoProject, containerID = expectedPartitionId,
+            containmentName = "projects")
 
         // I can retrieve the entire partition
         // todoAccount.projects.add(todoProject)
         // todoAccount.assignParents()
         val retrievedTodoAccount = kolasuClient.getLionWebNode(expectedPartitionId)
         assertEquals(1, retrievedTodoAccount.getChildrenByContainmentName("projects").size)
-        assertEquals(listOf(todoProjectID), retrievedTodoAccount.getChildrenByContainmentName("projects").map { it.id })
+        assertEquals(listOf(todoProjectID), retrievedTodoAccount.getChildrenByContainmentName("projects")
+            .map { it.id })
 
         // I can retrieve just a portion of that partition. In that case the parent of the root of the
         // subtree will appear null
@@ -79,7 +88,9 @@ class TodoFunctionalTest : AbstractRepoClientFunctionalTest(lionWebVersion = LIO
 
     @Test
     fun checkNodeIDs() {
-        val kolasuClient = KolasuClient(port = modelRepository!!.firstMappedPort, debug = true)
+        val kolasuClient = KolasuClient(port = modelRepository!!.firstMappedPort, debug = true,
+            repository = "repo_checkNodeIDs")
+        kolasuClient.createRepository()
         kolasuClient.registerLanguage(todoLanguage)
         kolasuClient.registerLanguage(todoAccountLanguage)
 
@@ -114,9 +125,13 @@ class TodoFunctionalTest : AbstractRepoClientFunctionalTest(lionWebVersion = LIO
 
     @Test
     fun sourceIsRetrievedCorrectly() {
-        val kolasuClient = KolasuClient(port = modelRepository!!.firstMappedPort, debug = true)
+        val kolasuClient = KolasuClient(port = modelRepository!!.firstMappedPort, debug = true,
+            repository = "repo_sourceIsRetrievedCorrectly")
+        kolasuClient.createRepository()
         kolasuClient.registerLanguage(todoLanguage)
         kolasuClient.registerLanguage(todoAccountLanguage)
+        registerSerializersAndDeserializersInMetamodelRegistry()
+        MetamodelRegistry.prepareJsonSerialization(kolasuClient.jsonSerialization)
 
         // We create an empty partition
         val todoAccount = TodoAccount("my-wonderful-partition")

--- a/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
+++ b/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
@@ -389,6 +389,10 @@ class KolasuClient(
     // Other operations
     //
 
+    fun createRepository() {
+        lionWebClient.createRepository(lionWebClient.repository, lionWebClient.lionWebVersion)
+    }
+
     /**
      * Return the Node ID associated to the Node. If the Client has already "seen"
      * the Node before associated to a particular Node ID (either during insertion or retrieval)

--- a/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
+++ b/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
@@ -53,7 +53,7 @@ import kotlin.reflect.KProperty1
  */
 class KolasuClient(
     hostname: String = "localhost",
-    val port: Int = 3005,
+    port: Int = 3005,
     repository: String = "default",
     val debug: Boolean = false,
     connectTimeOutInSeconds: Long = 60,
@@ -61,6 +61,15 @@ class KolasuClient(
     authorizationToken: String? = null,
     val idProvider: NodeIdProvider = CommonNodeIdProvider().caching()
 ) {
+    val hostname: String
+        get() = lionWebClient.hostname
+
+    val port: Int
+        get() = lionWebClient.port
+
+    val repository: String
+        get() = lionWebClient.repository
+
     /**
      * Exposed for testing purposes
      */

--- a/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
+++ b/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
@@ -21,8 +21,6 @@ import io.lionweb.lioncore.java.language.Concept
 import io.lionweb.lioncore.java.model.HasSettableParent
 import io.lionweb.lioncore.java.model.impl.ProxyNode
 import io.lionweb.lioncore.java.serialization.JsonSerialization
-import io.lionweb.lioncore.java.serialization.SerializationProvider
-import io.lionweb.lioncore.java.serialization.UnavailableNodePolicy
 import io.lionweb.lioncore.kotlin.repoclient.ClassifierResult
 import io.lionweb.lioncore.kotlin.repoclient.LionWebClient
 import io.lionweb.lioncore.kotlin.repoclient.RetrievalMode
@@ -54,13 +52,13 @@ import kotlin.reflect.KProperty1
  * or (iii) implement IDLogic.
  */
 class KolasuClient(
-    val hostname: String = "localhost",
+    hostname: String = "localhost",
     val port: Int = 3005,
-    val repository: String = "default",
+    repository: String = "default",
     val debug: Boolean = false,
     connectTimeOutInSeconds: Long = 60,
     callTimeoutInSeconds: Long = 60,
-    val authorizationToken: String? = null,
+    authorizationToken: String? = null,
     val idProvider: NodeIdProvider = CommonNodeIdProvider().caching()
 ) {
     /**
@@ -84,39 +82,8 @@ class KolasuClient(
             lionWebVersion = LIONWEB_VERSION_USED_BY_KOLASU
         )
 
-    private val serializationDecorators = mutableListOf<SerializationDecorator>()
-
-    init {
-        registerSerializationDecorator {
-            it.apply {
-                enableDynamicNodes()
-                unavailableParentPolicy = UnavailableNodePolicy.NULL_REFERENCES
-                unavailableReferenceTargetPolicy = UnavailableNodePolicy.PROXY_NODES
-            }
-            nodeConverter.prepareSerialization(
-                it
-            ) as JsonSerialization
-        }
-    }
-
-    /**
-     * Exposed for testing purposes
-     */
-    @Deprecated("This does not affect the serialization used by the underlying LionWebClient")
-    var jsonSerialization: JsonSerialization = calculateSerialization()
-        private set
-
-    @Deprecated("This does not affect the serialization used by the underlying LionWebClient")
-    fun updateSerialization() {
-        this.jsonSerialization = calculateSerialization()
-    }
-
-    @Deprecated("This does not affect the serialization used by the underlying LionWebClient")
-    private fun calculateSerialization() : JsonSerialization {
-        val jsonSerialization = SerializationProvider.getStandardJsonSerialization(LIONWEB_VERSION_USED_BY_KOLASU)
-        serializationDecorators.forEach { serializationDecorator -> serializationDecorator.invoke(jsonSerialization) }
-        return jsonSerialization
-    }
+    val jsonSerialization: JsonSerialization
+        get() = lionWebClient.jsonSerialization
 
     //
     // Configuration
@@ -480,11 +447,6 @@ class KolasuClient(
             idProvider,
             considerParent = true,
         )
-    }
-
-    fun registerSerializationDecorator(decorator: SerializationDecorator) {
-        // We do not need to specify them also for the lionWebClient, as it uses ours version of JsonSerialization
-        serializationDecorators.add(decorator)
     }
 
 }

--- a/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
+++ b/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
@@ -24,7 +24,6 @@ import io.lionweb.lioncore.java.serialization.JsonSerialization
 import io.lionweb.lioncore.kotlin.repoclient.ClassifierResult
 import io.lionweb.lioncore.kotlin.repoclient.LionWebClient
 import io.lionweb.lioncore.kotlin.repoclient.RetrievalMode
-import io.lionweb.lioncore.kotlin.repoclient.SerializationDecorator
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 

--- a/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
+++ b/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
@@ -58,8 +58,8 @@ class KolasuClient(
     val port: Int = 3005,
     val repository: String = "default",
     val debug: Boolean = false,
-    val connectTimeOutInSeconds: Long = 60,
-    val callTimeoutInSeconds: Long = 60,
+    connectTimeOutInSeconds: Long = 60,
+    callTimeoutInSeconds: Long = 60,
     val authorizationToken: String? = null,
     val idProvider: NodeIdProvider = CommonNodeIdProvider().caching()
 ) {
@@ -102,14 +102,16 @@ class KolasuClient(
     /**
      * Exposed for testing purposes
      */
+    @Deprecated("This does not affect the serialization used by the underlying LionWebClient")
     var jsonSerialization: JsonSerialization = calculateSerialization()
         private set
 
+    @Deprecated("This does not affect the serialization used by the underlying LionWebClient")
     fun updateSerialization() {
         this.jsonSerialization = calculateSerialization()
-        lionWebClient.updateJsonSerialization()
     }
 
+    @Deprecated("This does not affect the serialization used by the underlying LionWebClient")
     private fun calculateSerialization() : JsonSerialization {
         val jsonSerialization = SerializationProvider.getStandardJsonSerialization(LIONWEB_VERSION_USED_BY_KOLASU)
         serializationDecorators.forEach { serializationDecorator -> serializationDecorator.invoke(jsonSerialization) }

--- a/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
+++ b/lionwebrepo-client/src/main/kotlin/com/strumenta/kolasu/lionwebclient/KolasuClient.kt
@@ -27,7 +27,6 @@ import io.lionweb.lioncore.kotlin.repoclient.ClassifierResult
 import io.lionweb.lioncore.kotlin.repoclient.LionWebClient
 import io.lionweb.lioncore.kotlin.repoclient.RetrievalMode
 import io.lionweb.lioncore.kotlin.repoclient.SerializationDecorator
-import io.lionweb.lioncore.kotlin.repoclient.debugFileHelper
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 
@@ -214,10 +213,6 @@ class KolasuClient(
         }
         val lwTreeToAppend = toLionWeb(kNode, containerID, containmentName, containmentIndex)
         considerLogging("attachAST - prepared lwTreeToAppend")
-        debugFile("createNode-${lwTreeToAppend.id}.json") {
-            (nodeConverter.prepareSerialization() as JsonSerialization).serializeTreesToJsonString(lwTreeToAppend)
-        }
-        considerLogging("attachAST - debug file prepared")
         lionWebClient.appendTree(lwTreeToAppend, containerID, containmentName, containmentIndex)
         considerLogging("attachAST - actual lionweb appending done")
         return lwTreeToAppend.id!!
@@ -337,11 +332,8 @@ class KolasuClient(
         }
     }
 
-    fun getLionWebNode(
-        nodeID: String,
-        withProxyParent: Boolean = false,
-    ): LWNode {
-        return lionWebClient.retrieve(nodeID, withProxyParent)
+    fun getLionWebNode(nodeID: String): LWNode {
+        return lionWebClient.retrieve(nodeID)
     }
 
     fun attachLionWebChild(
@@ -371,7 +363,6 @@ class KolasuClient(
     ): String {
         val updatedParent = lionWebClient.retrieve(
                 parentID,
-                withProxyParent = true,
                 retrievalMode = RetrievalMode.SINGLE_NODE,
             )
         return attachLionWebChild(child, updatedParent, propertyName)
@@ -400,29 +391,20 @@ class KolasuClient(
         return lionWebClient.storeTree(lwNode)
     }
 
-    fun getShallowLionWebNode(
-        nodeID: String,
-        withProxyParent: Boolean = false,
-    ): LWNode {
-        val result = lionWebClient.retrieve(nodeID, withProxyParent, retrievalMode = RetrievalMode.SINGLE_NODE)
+    fun getShallowLionWebNode(nodeID: String): LWNode {
+        val result = lionWebClient.retrieve(nodeID, retrievalMode = RetrievalMode.SINGLE_NODE)
         require(result !is ProxyNode) {
             "The LionWebClient should not retrieve a node as a ProxyNode"
         }
         return result
     }
 
-    fun getShallowLionWebNodes(
-        nodeIDs: List<String>,
-        withProxyParent: Boolean = false,
-    ): List<LWNode> {
-        return lionWebClient.retrieve(nodeIDs, withProxyParent, retrievalMode = RetrievalMode.SINGLE_NODE)
+    fun getShallowLionWebNodes(nodeIDs: List<String>): List<LWNode> {
+        return lionWebClient.retrieve(nodeIDs, retrievalMode = RetrievalMode.SINGLE_NODE)
     }
 
-    fun getFullLionWebNodes(
-        nodeIDs: List<String>,
-        withProxyParent: Boolean = false,
-    ): List<LWNode> {
-        return lionWebClient.retrieve(nodeIDs, withProxyParent, retrievalMode = RetrievalMode.ENTIRE_SUBTREE)
+    fun getFullLionWebNodes(nodeIDs: List<String>): List<LWNode> {
+        return lionWebClient.retrieve(nodeIDs, retrievalMode = RetrievalMode.ENTIRE_SUBTREE)
     }
 
     //
@@ -496,13 +478,6 @@ class KolasuClient(
             idProvider,
             considerParent = true,
         )
-    }
-
-    private fun debugFile(
-        relativePath: String,
-        text: () -> String,
-    ) {
-        debugFileHelper(debug, relativePath, text)
     }
 
     fun registerSerializationDecorator(decorator: SerializationDecorator) {

--- a/playground/build.gradle
+++ b/playground/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: "$kotlin_version"
-    implementation "com.google.code.gson:gson:$gson_version"
+    implementation(libs.gson)
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"


### PR DESCRIPTION
As part of this PR we do minor maintenance operations:
- We update the version of gson used and adopt the version catalog for managing such version
- We update the versions of LW Java, LW Kotlin,  StarLasu Specs
- We add the parameter jsonSerialization to convertCodebase
- We expose the serializers and deserializers for the StarLasuLWLanguage (a.k.a. ASTLanguage), so that they can be used individually from users of Kolasu
- We update TodoFunctionalTest to create a separate repository for each test. This is necessary because now the base class AbstractRepoClientFunctionalTest does not recreate the whole DB for each test
- In KolasuClient we do not keep a separate JsonSerialization, but we use the one of the wrapped LionWebClient

Depends on https://github.com/LionWeb-io/lionweb-kotlin/pull/9