### PR TITLE
Fix serialization

### DIFF
--- a/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/CodebaseAdapters.kt
+++ b/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/CodebaseAdapters.kt
@@ -63,7 +63,7 @@ fun <R : Node> convertCodebase(
 
         private val filesCache: List<CodebaseFile<R>> by lazy {
             codebaseAccess.files().map { fileIdentifier ->
-                val serializedFile = codebaseAccess.retrieveFile(fileIdentifier)
+                val serializedFile = codebaseAccess.retrieve(fileIdentifier)
                 jsonSerialization.deserializeToNodes(serializedFile)[0]
             }.filter { serializedCodebaseFile ->
                 val languageName = serializedCodebaseFile!!.getPropertyValueByName("language_name") as String

--- a/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/CodebaseAdapters.kt
+++ b/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/CodebaseAdapters.kt
@@ -3,6 +3,7 @@ package com.strumenta.kolasu.codebase
 import com.strumenta.kolasu.lionweb.IssueNode
 import com.strumenta.kolasu.lionweb.LWNode
 import com.strumenta.kolasu.lionweb.LionWebModelConverter
+import com.strumenta.kolasu.lionweb.TokensList
 import com.strumenta.kolasu.model.Node
 import com.strumenta.starlasu.base.CodebaseAccess
 import com.strumenta.starlasu.base.CodebaseLanguage
@@ -28,7 +29,8 @@ fun <R : Node> deserialize(
         codebaseFile.getChildrenByContainmentName("issues").map { lwIssue ->
             modelConverter.importIssueFromLionweb(lwIssue as IssueNode).second
         }
-    return CodebaseFile(codebase, relativePath, code, compilationUnit, issues)
+    val tokens = codebaseFile.getPropertyValueByName("tokens") as TokensList
+    return CodebaseFile(codebase, relativePath, code, compilationUnit, tokens, issues)
 }
 
 fun <R : Node> serialize(
@@ -41,6 +43,7 @@ fun <R : Node> serialize(
     lwCodebaseFile.setPropertyValueByName("language_name", languageName)
     lwCodebaseFile.setPropertyValueByName("relative_path", codebaseFile.relativePath)
     lwCodebaseFile.setPropertyValueByName("code", codebaseFile.code)
+    lwCodebaseFile.setPropertyValueByName("tokens", codebaseFile.tokens)
     modelConverter.clearNodesMapping()
     val ast = modelConverter.exportModelToLionWeb(codebaseFile.ast)
     ClassifierInstanceUtils.setOnlyChildByContainmentName(lwCodebaseFile, "ast", ast)

--- a/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/CodebaseFile.kt
+++ b/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/CodebaseFile.kt
@@ -1,5 +1,6 @@
 package com.strumenta.kolasu.codebase
 
+import com.strumenta.kolasu.lionweb.TokensList
 import com.strumenta.kolasu.model.CodeBaseSource
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.PropertyType
@@ -13,6 +14,7 @@ data class CodebaseFile<R : Node>(
     val relativePath: String,
     var code: String,
     var ast: R,
+    var tokens: TokensList?,
     val parsingIssues: List<Issue> = emptyList()
 ) {
 

--- a/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/FileBasedCodebase.kt
+++ b/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/FileBasedCodebase.kt
@@ -39,6 +39,7 @@ class FileBasedCodebase<R : Node>(
                                             relativePath,
                                             child.readText(),
                                             root,
+                                            null,
                                             parsingResult.issues
                                         )
                                         yield(codebaseFile)

--- a/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/FileBasedCodebase.kt
+++ b/codebase/src/main/kotlin/com/strumenta/kolasu/codebase/FileBasedCodebase.kt
@@ -39,7 +39,7 @@ class FileBasedCodebase<R : Node>(
                                             relativePath,
                                             child.readText(),
                                             root,
-                                            null,
+                                            tokens = null,
                                             parsingResult.issues
                                         )
                                         yield(codebaseFile)

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
@@ -65,7 +65,7 @@ open class Node() : Origin, Destination, Serializable, HasID {
     @property:Internal
     open val originalProperties: List<PropertyDescription>
         get() = try {
-            properties.filter { !it.derived }
+            nodeOriginalProperties.map { PropertyDescription.buildFor(it, this) }
         } catch (e: Throwable) {
             throw RuntimeException("Issue while getting properties of node ${this::class.qualifiedName}", e)
         }

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
@@ -52,8 +52,12 @@ open class Node() : Origin, Destination, Serializable, HasID {
      */
     @property:Internal
     open val properties: List<PropertyDescription>
+        get() = originalProperties + derivedProperties
+
+    @property:Internal
+    open val derivedProperties: List<PropertyDescription>
         get() = try {
-            nodeProperties.map { PropertyDescription.buildFor(it, this) }
+            nodeDerivedProperties.map { PropertyDescription.buildFor(it, this) }
         } catch (e: Throwable) {
             throw RuntimeException("Issue while getting properties of node ${this::class.qualifiedName}", e)
         }

--- a/core/src/main/kotlin/com/strumenta/kolasu/model/Properties.kt
+++ b/core/src/main/kotlin/com/strumenta/kolasu/model/Properties.kt
@@ -10,6 +10,8 @@ val <T : Any> Class<T>.nodeProperties: Collection<KProperty1<T, *>>
     get() = this.kotlin.nodeProperties
 val <T : Any> Class<T>.nodeOriginalProperties: Collection<KProperty1<T, *>>
     get() = this.kotlin.nodeOriginalProperties
+val <T : Any> Class<T>.nodeDerivedProperties: Collection<KProperty1<T, *>>
+    get() = this.kotlin.nodeDerivedProperties
 val <T : Any> KClass<T>.nodeProperties: Collection<KProperty1<T, *>>
     get() = memberProperties.asSequence()
         .filter { it.visibility == KVisibility.PUBLIC }
@@ -27,6 +29,10 @@ val <T : Any> KClass<T>.nodeOriginalProperties: Collection<KProperty1<T, *>>
     get() = nodeProperties
         .filter { it.findAnnotation<Derived>() == null }
 
+val <T : Any> KClass<T>.nodeDerivedProperties: Collection<KProperty1<T, *>>
+    get() = nodeProperties
+        .filter { it.findAnnotation<Derived>() != null }
+
 /**
  * @return all properties of this node that are considered AST properties.
  */
@@ -38,3 +44,9 @@ val <T : Node> T.nodeProperties: Collection<KProperty1<T, *>>
  */
 val <T : Node> T.nodeOriginalProperties: Collection<KProperty1<T, *>>
     get() = this.javaClass.nodeOriginalProperties
+
+/**
+ * @return all derived properties of this node that are considered AST properties.
+ */
+val <T : Node> T.nodeDerivedProperties: Collection<KProperty1<T, *>>
+    get() = this.javaClass.nodeDerivedProperties

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 lwjava = "0.4.4"
 lwkotlin = "0.4.2"
 kotestVersion= "1.3.3"
-specsVersion = "0.2.0"
+specsVersion = "0.2.1"
 gson = "2.13.0"
 
 [plugins]

--- a/javalib/src/test/java/com/strumenta/kolasu/javalib/CompilationUnit.java
+++ b/javalib/src/test/java/com/strumenta/kolasu/javalib/CompilationUnit.java
@@ -4,6 +4,7 @@ import com.strumenta.kolasu.model.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -16,17 +17,16 @@ public class CompilationUnit extends Node {
             return bs;
         }
 
-        @NotNull
         @Override
-        @Internal
-        public List<PropertyDescription> getProperties() {
+        @NotNull
+        public List<PropertyDescription> getOriginalProperties() {
             return Arrays.asList(new PropertyDescription("bs", true, Multiplicity.MANY, getBs(), PropertyType.CONTAINMENT, false));
         }
 
         @Override
         @NotNull
-        public List<PropertyDescription> getOriginalProperties() {
-            return getProperties();
+        public List<PropertyDescription> getDerivedProperties() {
+            return Collections.emptyList();
         }
     }
 

--- a/javalib/src/test/java/com/strumenta/kolasu/javalib/CompilationUnit.java
+++ b/javalib/src/test/java/com/strumenta/kolasu/javalib/CompilationUnit.java
@@ -22,6 +22,12 @@ public class CompilationUnit extends Node {
         public List<PropertyDescription> getProperties() {
             return Arrays.asList(new PropertyDescription("bs", true, Multiplicity.MANY, getBs(), PropertyType.CONTAINMENT, false));
         }
+
+        @Override
+        @NotNull
+        public List<PropertyDescription> getOriginalProperties() {
+            return getProperties();
+        }
     }
 
     public static class B extends Node {
@@ -39,5 +45,11 @@ public class CompilationUnit extends Node {
     @Internal
     public List<PropertyDescription> getProperties() {
         return Arrays.asList(new PropertyDescription("as", true, Multiplicity.MANY, getAs(), PropertyType.CONTAINMENT, false));
+    }
+
+    @Override
+    @NotNull
+    public List<PropertyDescription> getOriginalProperties() {
+        return getProperties();
     }
 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/LionWebModelConverter.kt
@@ -926,7 +926,7 @@ class LionWebModelConverter(
         ) as IssueSeverity
         val position = issueNode.getPropertyValue(
             ASTLanguage.getIssue().getPropertyByName(Issue::position.name)!!
-        ) as Position
+        ) as? Position
         val issue = Issue(issueType, message, severity, position)
         return issueNode.id!! to issue
     }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/PrimitiveSerialization.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/PrimitiveSerialization.kt
@@ -79,7 +79,7 @@ val positionDeserializer = PrimitiveDeserializer<Position> { serialized ->
     }
     val parts = serialized.split("-")
     require(parts.size == 2) {
-        "Position has an expected format: $serialized"
+        "Position has an unexpected format: $serialized"
     }
     Position(pointDeserializer.deserialize(parts[0]), pointDeserializer.deserialize(parts[1]))
 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/PrimitiveSerialization.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/PrimitiveSerialization.kt
@@ -11,7 +11,6 @@ import io.lionweb.lioncore.kotlin.MetamodelRegistry
 
 fun registerSerializersAndDeserializersInMetamodelRegistry() {
     MetamodelRegistry.addSerializerAndDeserializer(ASTLanguage.getChar(), charSerializer, charDeserializer)
-    MetamodelRegistry.addSerializerAndDeserializer(StarLasuLWLanguage.Point, pointSerializer, pointDeserializer)
     MetamodelRegistry.addSerializerAndDeserializer(
         ASTLanguage.getPosition(),
         positionSerializer,

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/PrimitiveSerialization.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/PrimitiveSerialization.kt
@@ -4,15 +4,16 @@ import com.strumenta.kolasu.model.Point
 import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.parsing.KolasuToken
 import com.strumenta.kolasu.parsing.TokenCategory
+import com.strumenta.starlasu.base.ASTLanguage
 import io.lionweb.lioncore.java.serialization.PrimitiveValuesSerialization.PrimitiveDeserializer
 import io.lionweb.lioncore.java.serialization.PrimitiveValuesSerialization.PrimitiveSerializer
 import io.lionweb.lioncore.kotlin.MetamodelRegistry
 
 fun registerSerializersAndDeserializersInMetamodelRegistry() {
-    MetamodelRegistry.addSerializerAndDeserializer(StarLasuLWLanguage.Char, charSerializer, charDeserializer)
+    MetamodelRegistry.addSerializerAndDeserializer(ASTLanguage.getChar(), charSerializer, charDeserializer)
     MetamodelRegistry.addSerializerAndDeserializer(StarLasuLWLanguage.Point, pointSerializer, pointDeserializer)
     MetamodelRegistry.addSerializerAndDeserializer(
-        StarLasuLWLanguage.Position,
+        ASTLanguage.getPosition(),
         positionSerializer,
         positionDeserializer
     )
@@ -30,6 +31,9 @@ class TokensList(val tokens: List<KolasuToken>)
 
 val charSerializer = PrimitiveSerializer<Char> { value -> "$value" }
 val charDeserializer = PrimitiveDeserializer<Char> { serialized ->
+    if (serialized == null) {
+        return@PrimitiveDeserializer null
+    }
     require(serialized.length == 1)
     serialized[0]
 }
@@ -63,19 +67,21 @@ val pointDeserializer: PrimitiveDeserializer<Point> =
 //
 
 val positionSerializer = PrimitiveSerializer<Position> { value ->
+    if (value == null) {
+        return@PrimitiveSerializer null
+    }
     "${pointSerializer.serialize((value as Position).start)}-${pointSerializer.serialize(value.end)}"
 }
 
 val positionDeserializer = PrimitiveDeserializer<Position> { serialized ->
     if (serialized == null) {
-        null
-    } else {
-        val parts = serialized.split("-")
-        require(parts.size == 2) {
-            "Position has an expected format: $serialized"
-        }
-        Position(pointDeserializer.deserialize(parts[0]), pointDeserializer.deserialize(parts[1]))
+        return@PrimitiveDeserializer null
     }
+    val parts = serialized.split("-")
+    require(parts.size == 2) {
+        "Position has an expected format: $serialized"
+    }
+    Position(pointDeserializer.deserialize(parts[0]), pointDeserializer.deserialize(parts[1]))
 }
 
 //
@@ -90,19 +96,18 @@ val tokensListPrimitiveSerializer = PrimitiveSerializer<TokensList?> { value: To
 
 val tokensListPrimitiveDeserializer = PrimitiveDeserializer<TokensList?> { serialized ->
     if (serialized == null) {
-        null
-    } else {
-        val tokens = if (serialized.isEmpty()) {
-            mutableListOf()
-        } else {
-            serialized.split(";").map {
-                val parts = it.split("$")
-                require(parts.size == 2)
-                val category = parts[0]
-                val position = positionDeserializer.deserialize(parts[1])
-                KolasuToken(TokenCategory(category), position)
-            }.toMutableList()
-        }
-        TokensList(tokens)
+        return@PrimitiveDeserializer null
     }
+    val tokens = if (serialized.isEmpty()) {
+        mutableListOf()
+    } else {
+        serialized.split(";").map {
+            val parts = it.split("$")
+            require(parts.size == 2)
+            val category = parts[0]
+            val position = positionDeserializer.deserialize(parts[1])
+            KolasuToken(TokenCategory(category), position)
+        }.toMutableList()
+    }
+    TokensList(tokens)
 }

--- a/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/PrimitiveSerialization.kt
+++ b/lionweb/src/main/kotlin/com/strumenta/kolasu/lionweb/PrimitiveSerialization.kt
@@ -16,10 +16,11 @@ fun registerSerializersAndDeserializersInMetamodelRegistry() {
         positionSerializer,
         positionDeserializer
     )
-
-    val tlpt = MetamodelRegistry.getPrimitiveType(TokensList::class, LIONWEB_VERSION_USED_BY_KOLASU)
-        ?: throw IllegalStateException("Unknown primitive type class ${TokensList::class}")
-    MetamodelRegistry.addSerializerAndDeserializer(tlpt, tokensListPrimitiveSerializer, tokensListPrimitiveDeserializer)
+    MetamodelRegistry.addSerializerAndDeserializer(
+        ASTLanguage.getTokensList(),
+        tokensListPrimitiveSerializer,
+        tokensListPrimitiveDeserializer
+    )
 }
 
 class TokensList(val tokens: List<KolasuToken>)


### PR DESCRIPTION
Fixing minor issues emerged while serializing to LionWeb.

* We update the Starlasu Specs to 0.2.1
* We ensure that when calculating the original properties we do not first calculate all properties (including derived properties) to later filter them out. This is important as calculation of derived properties could fail while we are building the node
* We correct support for serializing and deserializing null values for primitive types